### PR TITLE
add new mirror ftp.fau.de

### DIFF
--- a/mirrors.d/ftp.fau.de.yml
+++ b/mirrors.d/ftp.fau.de.yml
@@ -1,0 +1,11 @@
+---
+name: ftp.fau.de
+address:
+  http: http://ftp.fau.de/almalinux/
+  https: https://ftp.fau.de/almalinux/
+  rsync: rsync://ftp.fau.de/almalinux/
+update_frequency: 3h
+sponsor: Friedrich-Alexander-Universitaet Erlangen-Nuernberg
+sponsor_url: https://www.rrze.fau.de
+email: rrze-ftp-admin@fau.de
+...


### PR DESCRIPTION
two comments:
1. <strike>your mirroring-howto does not mention a recommended mirrorinterval, so for now we settled on _our_ default of 6 hours.</strike> no idea how I managed to overlook that, it does say 3 hours, I've updated both our config and the PR.
2. I don't see any 'country' or at least 'continent' field in the mirror infos, but you'll probably need that sooner or later to pre-filter the list of mirrors offered to a client as the mirrorlist gets larger and larger? Or do you plan to do that only via geoip?