### PR TITLE
altushost mirror included

### DIFF
--- a/mirrors.d/mirror.altushost.nl.yml
+++ b/mirrors.d/mirror.altushost.nl.yml
@@ -1,0 +1,10 @@
+---
+name: mirror.nl.altushost.com
+address:
+  http: http://mirror.nl.altushost.com/almalinux/
+  https: https://mirror.nl.altushost.com/almalinux/
+update_frequency: 1h
+sponsor: AltusHost B.V.
+sponsor_url: https://www.altushost.com/
+email: mirrors@altushost.com
+...


### PR DESCRIPTION
We have added the almalinux mirror which will be served from our NL location.

Kindly review and add it.