### PR TITLE
LU-2088: AlmaLinux mirrors support improvement

### DIFF
--- a/mirrors_update.py
+++ b/mirrors_update.py
@@ -25,6 +25,10 @@ DEFAULT_ARCH = 'x86_64'
 HEADERS = {
     'User-Agent': 'libdnf (AlmaLinux 8.3; generic; Linux.x86_64)'
 }
+# the list of mirrors which should be always available
+WHITELIST_MIRRORS = (
+    'repo.almalinux.org',
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -169,6 +173,9 @@ def get_verified_mirrors(
                     config_path,
                 )
                 continue
+            if mirror_info['name'] in WHITELIST_MIRRORS:
+                result.append(mirror_info)
+                continue
             if mirror_available(
                 mirror_info=mirror_info,
                 versions=versions,
@@ -267,7 +274,7 @@ def generate_mirrors_table(
             for protocol in ALL_MIRROR_PROTOCOLS:
                 if protocol in addresses:
                     link = f'[{address_prefixes[protocol]}]' \
-                           f'({addresses[protocol]})'
+                           f'({addresses[protocol].split("/")})'
                 else:
                     link = ''
                 mirror_info[f'{protocol}_link'] = link

--- a/mirrors_update.py
+++ b/mirrors_update.py
@@ -274,7 +274,7 @@ def generate_mirrors_table(
             for protocol in ALL_MIRROR_PROTOCOLS:
                 if protocol in addresses:
                     link = f'[{address_prefixes[protocol]}]' \
-                           f'({addresses[protocol].split("/")})'
+                           f'({addresses[protocol].strip("/")})'
                 else:
                     link = ''
                 mirror_info[f'{protocol}_link'] = link


### PR DESCRIPTION
- Mirror `repo.almalinux.org` is added to the whitelist
- Strip backslash from mirror's links 