### PR TITLE
Added Hostcentral's AlmaLinux mirror.

### DIFF
--- a/mirrors.d/mirror.as24220.net.yml
+++ b/mirrors.d/mirror.as24220.net.yml
@@ -1,0 +1,11 @@
+---
+name: mirror.as24220.net
+address:
+  http: http://mirror.as24220.net/almalinux/
+  https: https://mirror.as24220.net/almalinux/
+  rsync: rsync://mirror.as24220.net/almalinux
+update_frequency: 3h
+sponsor: Hostcentral
+sponsor_url: https://www.hostcentral.net.au
+email: dhill@hostcentral.net.au
+...


### PR DESCRIPTION
- Added mirror.as24220.net.yml
- Hosted in Melbourne, Australia.