### PR TITLE
New mirror

### DIFF
--- a/mirrors.d/gethosted.online.yml
+++ b/mirrors.d/gethosted.online.yml
@@ -1,0 +1,10 @@
+name: mirrors.gethosted.online
+address:
+  http: http://mirrors.gethosted.online/almalinux
+  https: https://mirrors.gethosted.online/almalinux
+  rsync: rsync://mirrors.gethosted.online/almalinux
+  ftp: ftp://mirrors.gethosted.online/almalinux
+update_frequency: 6h
+sponsor: Get Hosted Online
+sponsor_url: https://www.gethosted.online
+email: support@gethosted.online


### PR DESCRIPTION
Hi

This contains mirror information from Get Hosted Online - UK, London - DDoS Protected.

Our commitment to supporting open source projects continues with the inclusion of AlmaLinux. Currently we sponsor GNU, Gnome, KDE, CentOS, Ubuntu, Apache, etc and are looking to extend our mirror service to AlmaLinux.

The changes reflect those found in the AlmaLinux example file, in the repository.

Kind regards 