### PR TITLE
New Frankfurt Mirror proposal

### DIFF
--- a/mirrors.d/almalinux.li.yml
+++ b/mirrors.d/almalinux.li.yml
@@ -1,0 +1,10 @@
+---
+name: almalinux.li
+address:
+  http: http://almalinux.li/
+  https: https://almalinux.li/
+update_frequency: 3h
+sponsor: /dev/null/v
+sponsor_url: https://dev.nul.lv
+email: mirror@almalinux.li
+...


### PR DESCRIPTION
Hello,
this request adds a mirror in Germany, Frankfurt with 10Gbps Bandwidth and DDoS filters.

/dev/null/v is commited in supporting open source projects with space and by running live examples of them.
The recommended 3h update cron is set.
This mirror also fully supports IPv6, which unfortunately still seems to be a rarity.

Best regards,
Alex