### PR TITLE
fix typo in contact email for ftp.fau.de

### DIFF
--- a/mirrors.d/ftp.fau.de.yml
+++ b/mirrors.d/ftp.fau.de.yml
@@ -7,5 +7,5 @@ address:
 update_frequency: 3h
 sponsor: Friedrich-Alexander-Universitaet Erlangen-Nuernberg
 sponsor_url: https://www.rrze.fau.de
-email: rrze-ftp-admin@fau.de
+email: rrze-ftp-admins@fau.de
 ...


### PR DESCRIPTION
unfortunately, I made a typo in the email address when originally submitting the mirror, as noticed by jaboutboul in #18. This fixes the typo.