### PR TITLE
Update mirror.hosting.com.tr.yml

### DIFF
--- a/mirrors.d/mirror.hosting.com.tr.yml
+++ b/mirrors.d/mirror.hosting.com.tr.yml
@@ -4,6 +4,6 @@ address:
   http: http://mirror.hosting.com.tr/almalinux/
 update_frequency: 3h
 sponsor: Hosting
-sponsor_url: https://www.hosting.com.tr
+sponsor_url: https://www.hosting.com.tr 
 email: mirror@hosting.com.tr
 ...


### PR DESCRIPTION
Why this link is removed I didn't understand. Would you please take a look and add it again?