### PR TITLE
New german mirror at ftp.gwdg.de

### DIFF
--- a/mirrors.d/ftp.gwdg.de.yml
+++ b/mirrors.d/ftp.gwdg.de.yml
@@ -1,0 +1,11 @@
+---
+name: ftp.gwdg.de
+address:
+  http: http://ftp.gwdg.de/pub/linux/almalinux/
+  https: https://ftp.gwdg.de/pub/linux/almalinux/
+  rsync: rsync://ftp.gwdg.de/almalinux
+update_frequency: 3h
+sponsor: Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen
+sponsor_url: https://www.gwdg.de
+email: ftpmaster@gwdg.de
+...


### PR DESCRIPTION
The GWDG provides a new mirror for AlmaLinux with https, http, ftp and rsync access. We are IPv6 enabled and have a good uplink to the DFN.