### PR TITLE
Added mirror.terrahost.no

### DIFF
--- a/mirrors.d/mirror.terrahost.no.yml
+++ b/mirrors.d/mirror.terrahost.no.yml
@@ -1,0 +1,11 @@
+---
+name: mirror.terrahost.no
+address:
+  http: http://mirror.terrahost.no/almalinux/
+  https: https://mirror.terrahost.no/almalinux/
+update_frequency: 3h
+sponsor: Terrahost AS
+sponsor_url: https://terrahost.no/
+email: noc@terrahost.no
+...
+


### PR DESCRIPTION
Norwegian mirror for AlmaLinux hosted by Terrahost.no.