### PR TITLE
Add new mirror in japan: ftp.iij.ad.jp

### DIFF
--- a/mirrors.d/ftp.iij.ad.jp.yml
+++ b/mirrors.d/ftp.iij.ad.jp.yml
@@ -1,0 +1,11 @@
+---
+name: ftp.iij.ad.jp
+address:
+  http: http://ftp.iij.ad.jp/pub/linux/almalinux/
+  https: https://ftp.iij.ad.jp/pub/linux/almalinux/
+  rsync: rsync://ftp.iij.ad.jp/pub/linux/almalinux
+update_frequency: 4h
+sponsor: Internet Initiative Japan Inc.
+sponsor_url: https://www.iij.ad.jp/en/
+email: mirror-contact@iij.ad.jp
+...


### PR DESCRIPTION
IIJ/AS2497 provides a new mirror for AlmaLinux with http, https, and rsync access.