### PR TITLE
Create mirror.vtti.vt.edu.yml

### DIFF
--- a/mirrors.d/mirror.vtti.vt.edu.yml
+++ b/mirrors.d/mirror.vtti.vt.edu.yml
@@ -1,0 +1,10 @@
+---
+name: mirror.vtti.vt.edu
+address:
+  http: http://mirror.vtti.vt.edu/almalinux/
+  https: https://mirror.vtti.vt.edu/almalinux/
+update_frequency: 3h
+sponsor: Virginia Tech Transportation Institute
+sponsor_url: https://www.vtti.vt.edu
+email: mirror@vtti.vt.edu
+...


### PR DESCRIPTION
I am the maintainer for mirror.vtti.vt.edu, which is the primary mirror at Virginia Tech. We support IPv4 and IPv6 on a dedicated 1Gbps link. We're also Internet2 connected and are working on a 10Gbps link for I2. I put http and https for now, but if you need additional rsync mirrors I can add support for that as well, just let me know.