### PR TITLE
feat: Add mirror.csclub.uwaterloo.ca

### DIFF
--- a/mirrors.d/mirror.csclub.uwaterloo.ca.yml
+++ b/mirrors.d/mirror.csclub.uwaterloo.ca.yml
@@ -1,0 +1,11 @@
+---
+name: mirror.csclub.uwaterloo.ca
+address:
+  http: http://mirror.csclub.uwaterloo.ca/almalinux/
+  https: https://mirror.csclub.uwaterloo.ca/almalinux/
+  rsync: rsync://mirror.csclub.uwaterloo.ca/almalinux/
+  ftp: ftp://mirror.csclub.uwaterloo.ca/almalinux/
+update_frequency: 2h
+sponsor: Computer Science Club of the University of Waterloo
+sponsor_url: https://csclub.uwaterloo.ca
+email: systems-committee@csclub.uwaterloo.ca


### PR DESCRIPTION
The Computer Science Club of the University of Waterloo has decided to mirror the AlmaLinux repository. Can we please be added to the mirror list? Thanks!