### PR TITLE
Added Rackspace Technology Mirror

### DIFF
--- a/mirrors.d/mirror.rackspace.com.yml
+++ b/mirrors.d/mirror.rackspace.com.yml
@@ -1,0 +1,11 @@
+---
+name: mirror.rackspace.com
+address:
+  http: http://mirror.rackspace.com/almalinux/
+  https: https://mirror.rackspace.com/almalinux/
+  rsync: rsync://mirror.rackspace.com/almalinux
+update_frequency: 4h
+sponsor: Rackspace Technology
+sponsor_url: https://www.rackspace.com
+email: mirroradmin@rackspace.com
+...


### PR DESCRIPTION
Request to add mirror.rackspace.com to Alma Linux project mirror infrastructure. All content has been synced and should be accessible. Mirror is globally load balanced in the following regions:

US
Dallas, TX
Chicago, IL
Dulles, VA

UK
London

AU
Sydney

CN
Hong Kong

Sam P
Linux Patching
Rackspace Technology