### PR TITLE
Mirror: Add Spry Servers - Phoenix, AZ USA

### DIFF
--- a/mirrors.d/mirror.phx1.us.spryservers.net.yml
+++ b/mirrors.d/mirror.phx1.us.spryservers.net.yml
@@ -1,0 +1,12 @@
+---
+name: mirror.phx1.us.spryservers.net
+address:
+  http: http://mirror.phx1.us.spryservers.net/almalinux/
+  https: https://mirror.phx1.us.spryservers.net/almalinux/
+  rsync: rsync://mirror.phx1.us.spryservers.net/almalinux
+  ftp: ftp://mirror.phx1.us.spryservers.net/almalinux/
+update_frequency: 3h
+sponsor: Spry Servers
+sponsor_url: https://www.spryservers.net
+email: mirrors@spryservers.net
+...


### PR DESCRIPTION
Add Spry Servers PHX1, US mirror - mirror.phx1.us.spryservers.net