### PR TITLE
Adding mirrors.d yaml file for Servers Australia mirror

### DIFF
--- a/mirrors.d/alma.serversaustralia.com.au.yml
+++ b/mirrors.d/alma.serversaustralia.com.au.yml
@@ -1,0 +1,11 @@
+---
+name: alma.serversaustralia.com.au
+address:
+  http: http://alma.mirror.serversaustralia.com.au/
+  https: https://alma.mirror.serversaustralia.com.au/
+  rsync: rsync://alma.mirror.serversaustralia.com.au/alma
+update_frequency: 3h
+sponsor: Servers Australia Pty Ltd
+sponsor_url: https://serversaustralia.com.au/
+email: shane.hutter@serversaustralia.com.au
+...


### PR DESCRIPTION
I've added an AlmaLinux mirror on the infrastructure for the company I work for, Servers Australia.  We are cPanel partners, and given that Alma will be supported by cPanel, and is maintained by Cloudlinux, a mirror on our network would likely be beneficial for both of us.