### PR TITLE
Fixing the name for the mirror

### DIFF
--- a/mirrors.d/alma.mirror.serversaustralia.com.au.yml
+++ b/mirrors.d/alma.mirror.serversaustralia.com.au.yml
@@ -1,5 +1,5 @@
 ---
-name: alma.serversaustralia.com.au
+name: alma.mirror.serversaustralia.com.au
 address:
   http: http://alma.mirror.serversaustralia.com.au/
   https: https://alma.mirror.serversaustralia.com.au/


### PR DESCRIPTION
My apologies, the name for our mirror did not reflect the URL for the mirror.  I've fixed it in the yaml file.
alma.serversaustralia.com.au has been changed to alma.mirror.serversaustralia.com.au in the name, to accurately reflect the domain name for the mirror.