### PR TITLE
It's fixed updating mirrors

### DIFF
--- a/ci/ansible/roles/deploy/defaults/main.yml
+++ b/ci/ansible/roles/deploy/defaults/main.yml
@@ -19,6 +19,8 @@ dnf_packages:
   - redis
   - nginx
   - gcc
+  # for testing purposes
+  - sqlite
 python_packages:
   - alembic==1.7.1
   - beautifulsoup4==4.10.0

--- a/ci/ansible/roles/deploy/tasks/common_setup.yml
+++ b/ci/ansible/roles/deploy/tasks/common_setup.yml
@@ -44,3 +44,18 @@
     state: present
     sysctl_set: yes
     reload: yes
+
+- name: Enable persistent journald
+  ini_file:
+    section: Journal
+    path: /etc/systemd/journald.conf
+    option: Storage
+    value: persistant
+  register:
+    persistent_journald
+
+- name: Restart journald
+  systemd:
+    state: restarted
+    name: systemd-journald
+  when: persistent_journald.changed

--- a/ci/ansible/roles/deploy/tasks/get_mirrors_repo.yml
+++ b/ci/ansible/roles/deploy/tasks/get_mirrors_repo.yml
@@ -6,3 +6,10 @@
     clone: yes
     update: yes
     accept_hostkey: yes
+
+- name: Change owner of local repo
+  file:
+    path: "{{ config_root }}/mirrors/updates"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    recurse: yes

--- a/ci/ansible/roles/deploy/templates/uwsgi.ini.j2
+++ b/ci/ansible/roles/deploy/templates/uwsgi.ini.j2
@@ -6,7 +6,7 @@ master = true
 processes = {{ uwsgi_processes }}
 uid = {{ service_user }}
 gid = {{ service_user }}
-http-timeout = 1800
+http-timeout = 3600
 enable-threads = true
 log-x-forwarded-for = true
 # disable OS/IO errors in logs when a client closed connection

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -263,9 +263,6 @@ async def update_mirrors_handler() -> AnyStr:
 
     with session_scope() as db_session:
         db_session.query(Mirror).delete()
-        db_session.query(Subnet).delete()
-        db_session.query(mirrors_urls).delete()
-        db_session.query(mirrors_subnets).delete()
         subnets = get_aws_subnets()
         subnets.update(get_azure_subnets())
         len_list = len(all_mirrors)

--- a/src/backend/api/mirrors_update.py
+++ b/src/backend/api/mirrors_update.py
@@ -189,16 +189,17 @@ async def mirror_available(
                 async with http_session.get(
                     check_url,
                     headers=HEADERS,
-                    timeout=15,
+                    timeout=45,
                 ) as resp:
                     await resp.text()
-            except (ClientError, asyncio.TimeoutError):
-                logger.warning(
+            except (ClientError, asyncio.TimeoutError) as err:
+                logger.error(
                     'Mirror "%s" is not available for version '
-                    '"%s" and repo path "%s"',
+                    '"%s" and repo path "%s" because "%s"',
                     mirror_name,
                     version,
                     repo_path,
+                    err,
                 )
                 return mirror_name, False
     logger.info(

--- a/src/backend/common/sentry.py
+++ b/src/backend/common/sentry.py
@@ -49,7 +49,7 @@ def init_sentry_client(dsn: Optional[str] = None) -> None:
             RedisIntegration(),
         ],
     )
-    if os.getenv('SKIP_AWS_CHECKING', 'False') != 'True':
+    if not os.getenv('SKIP_AWS_CHECKING'):
         with sentry_sdk.configure_scope() as scope:
             scope.set_tag('aws_instance_ip', get_aws_instance_api())
 

--- a/src/backend/common/sentry.py
+++ b/src/backend/common/sentry.py
@@ -49,8 +49,9 @@ def init_sentry_client(dsn: Optional[str] = None) -> None:
             RedisIntegration(),
         ],
     )
-    with sentry_sdk.configure_scope() as scope:
-        scope.set_tag('aws_instance_ip', get_aws_instance_api())
+    if os.getenv('SKIP_AWS_CHECKING', 'False') != 'True':
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_tag('aws_instance_ip', get_aws_instance_api())
 
 
 def get_logger(logger_name: str):

--- a/src/backend/db/dbmigrations/versions/519b9d9d7122_clear_old_data.py
+++ b/src/backend/db/dbmigrations/versions/519b9d9d7122_clear_old_data.py
@@ -1,0 +1,28 @@
+"""clear old data
+
+Revision ID: 819b9d9d7121
+Revises:
+Create Date: 2021-07-13 14:58:10.902027
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '519b9d9d7122'
+down_revision = '3df99e9174f4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('DELETE FROM mirrors')
+    op.execute('DELETE FROM mirrors_subnets')
+    op.execute('DELETE FROM mirrors_urls')
+    op.execute('DELETE FROM subnets')
+    op.execute('DELETE FROM urls')
+
+
+def downgrade():
+    pass

--- a/src/backend/db/utils.py
+++ b/src/backend/db/utils.py
@@ -8,6 +8,8 @@ from typing import List
 from alembic import command, script
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
+from sqlalchemy import event
+from sqlalchemy.engine import Engine as SAEngine
 from sqlalchemy.exc import OperationalError
 
 from db.db_engine import Engine
@@ -16,6 +18,13 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import Session
 
 BASE_REVISION = 'base'
+
+
+@event.listens_for(SAEngine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
 
 
 @contextmanager


### PR DESCRIPTION
- Install dnf package `sqlite` for testing purposes
- It's made logs of journald are persistent
- It's fixed owner of repo with mirror configs
- It's increased uwsgi http-timeout from 1800s to 3600s
  (because updating of the mirrors list can be too long)
- [SQLite] It's enabled `foreign_keys`
- It's fixed updating of the mirrors list
-- It's increased timeout of checking a mirror
-- It's used correct code for deleting the old mirrors
- We will get a Sentry event if a mirror isn't available