### PR TITLE
Fix name of mirror.team-cymru.com

### DIFF
--- a/mirrors.d/mirror.team-cymru.com.yml
+++ b/mirrors.d/mirror.team-cymru.com.yml
@@ -1,5 +1,5 @@
 ---
-name: repo.almalinux.org
+name: mirror.team-cymru.com
 address:
   http: http://mirror.team-cymru.com/almalinux
 update_frequency: 12h


### PR DESCRIPTION
The mirror `mirror.team-cymru.com` is not identical to `repo.almalinux.org` and therefore shouldn't be named like that.