### PR TITLE
add geolocation for ftp.fau.de

### DIFF
--- a/mirrors.d/ftp.fau.de.yml
+++ b/mirrors.d/ftp.fau.de.yml
@@ -4,6 +4,10 @@ address:
   http: http://ftp.fau.de/almalinux/
   https: https://ftp.fau.de/almalinux/
   rsync: rsync://ftp.fau.de/almalinux
+geolocation:
+  country: DE
+  state_province: Bavaria
+  city: Erlangen
 update_frequency: 3h
 sponsor: Friedrich-Alexander-Universitaet Erlangen-Nuernberg
 sponsor_url: https://www.rrze.fau.de


### PR DESCRIPTION
this commit adds the correct geolocation for ftp.fau.de.

Note: the geolocation in repo.almalinux.org.yml (which was used as a template to copy from) seems to be wrong: repo.almalinux.org seems to be hosted with Hetzner, but their data center is in Falkenstein/Vogtland, NOT the Falkenstein in Bavaria. So the correct state_province for repo.almalinux.org would be Saxony, NOT Bavaria!
