### PR TITLE
Add geolocation for YJSoft Mirror

### DIFF
--- a/mirrors.d/ftp.yjsoft.xyz.yml
+++ b/mirrors.d/ftp.yjsoft.xyz.yml
@@ -5,7 +5,7 @@ address:
   https: https://ftp.yjsoft.xyz/almalinux/
 geolocation:
   country: KR
-  state_province: Geumcheon-gu
+  state_province:
   city: Seoul
 update_frequency: 3h
 sponsor: YJSoft

--- a/mirrors.d/ftp.yjsoft.xyz.yml
+++ b/mirrors.d/ftp.yjsoft.xyz.yml
@@ -3,6 +3,10 @@ name: ftp.yjsoft.xyz
 address:
   http: http://ftp.yjsoft.xyz/almalinux/
   https: https://ftp.yjsoft.xyz/almalinux/
+geolocation:
+  country: KR
+  state_province: Geumcheon-gu
+  city: Seoul
 update_frequency: 3h
 sponsor: YJSoft
 sponsor_url: https://yjsoft.xyz


### PR DESCRIPTION
Added geolocation information per email request.

Since my mirror server uses AWS for proxy server, so Exact server location is unknown.
So instead of that, I put my storage server location(which is known)