### PR TITLE
ALBS-80: Mirror service: allow to have different set of repos for different AlmaLinux versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 .venv
 mirrors
-!ci/ansible/inventory/template
+ci/ansible/inventory/aws
 mirrors.db
 src/backend/db/geoip_db.mmdb
 src/backend/db/asn_db.mmdb

--- a/src/backend/api/mirrors_update.py
+++ b/src/backend/api/mirrors_update.py
@@ -103,6 +103,7 @@ def get_config(
                     name=repo['name'],
                     path=repo['path'],
                     arches=repo.get('arches', []),
+                    versions=[str(ver) for ver in repo.get('versions', [])],
                 ))
             return MainConfig(
                 allowed_outdate=config['allowed_outdate'],
@@ -229,6 +230,9 @@ async def mirror_available(
     for version in versions:
         for repo_data in repos:
             arches = repo_data.arches or arches
+            repo_versions = repo_data.versions
+            if repo_versions and version not in repo_versions:
+                continue
             repo_path = repo_data.path.replace('$basearch', arches[0])
             check_url = os.path.join(
                 mirror_url,
@@ -259,7 +263,7 @@ async def mirror_available(
                     mirror_name,
                     version,
                     repo_path,
-                    err,
+                    str(err) or type(err),
                 )
                 return mirror_name, False
     logger.info(

--- a/src/backend/db/data_models.py
+++ b/src/backend/db/data_models.py
@@ -96,6 +96,7 @@ class RepoData:
     name: str
     path: str
     arches: list[str] = field(default_factory=list)
+    versions: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/backend/db/json_schemas.py
+++ b/src/backend/db/json_schemas.py
@@ -196,6 +196,19 @@ MAIN_CONFIG = {
                     "items": {
                         "type": "string"
                     }
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    }
                 }
             },
             "required": [


### PR DESCRIPTION
- The subject is implemented. It's possible to set versions for any repo
- .gitignore is updated
- Logged error message is updated