### PR TITLE
Update ftp.lug.ro.yml

### DIFF
--- a/mirrors.d/ftp.lug.ro.yml
+++ b/mirrors.d/ftp.lug.ro.yml
@@ -2,6 +2,9 @@
 name: ftp.lug.ro
 address:
   http: http://ftp.lug.ro/almalinux/
+geolocation:
+  country: RO
+  city: Bucharest
 update_frequency: 2h
 sponsor: lug.ro
 sponsor_url: https://wiki.lug.ro


### PR DESCRIPTION
There is no state/province administrative division in Romania, just 41 counties plus Bucharest. Using Bucharest in the state field on nominatim yields 0 results, so I ommited the state_province field in the mirror template. If that's not ok, can you please suggest what to use instead?