### PR TITLE
added FlokiNET mirror

### DIFF
--- a/mirrors.d/mirror.flokinet.net.yml
+++ b/mirrors.d/mirror.flokinet.net.yml
@@ -1,0 +1,15 @@
+---
+name: mirror.flokinet.net
+address:
+  http: http://mirror.flokinet.net/almalinux/
+  https: https://mirror.flokinet.net/almalinux/
+  rsync: rsync://mirror.flokinet.net/almalinux
+geolocation:
+  country: RO
+  state_province: Municipality of Bucharest
+  city: Bucharest
+update_frequency: 3h
+sponsor: FlokiNET
+sponsor_url: https://flokinet.is
+email: noc@flokinet.is
+...

--- a/mirrors.d/mirror.flokinet.net.yml
+++ b/mirrors.d/mirror.flokinet.net.yml
@@ -6,7 +6,7 @@ address:
   rsync: rsync://mirror.flokinet.net/almalinux
 geolocation:
   country: RO
-  state_province: Municipality of Bucharest
+  state_province: "Municipality of Bucharest"
   city: Bucharest
 update_frequency: 3h
 sponsor: FlokiNET

--- a/mirrors.d/mirror.flokinet.net.yml
+++ b/mirrors.d/mirror.flokinet.net.yml
@@ -6,7 +6,7 @@ address:
   rsync: rsync://mirror.flokinet.net/almalinux
 geolocation:
   country: RO
-  state_province: "Municipality of Bucharest"
+  state_province:
   city: Bucharest
 update_frequency: 3h
 sponsor: FlokiNET


### PR DESCRIPTION
An almalinux mirror ist available under mirror.flokinet.net/almalinux via http, https and rsync