### PR TITLE
ALBS-139: The service should be able to return only a private mirror for suitable clients

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -68,6 +68,7 @@ class MirrorData:
     ipv6: Optional[bool] = None
     isos_link: Optional[str] = None
     asn: Optional[str] = None
+    monopoly: bool = False
     urls: dict[str, str] = field(default_factory=dict)
     subnets: list[str] = field(default_factory=list)
 
@@ -95,6 +96,7 @@ class MirrorData:
             asn=dct.get('asn'),
             urls=dct.get('urls'),
             subnets=dct.get('subnets'),
+            monopoly=dct.get('monopoly')
         )
 
     def to_json(self):

--- a/json_schemas/mirror_config.json
+++ b/json_schemas/mirror_config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "cloud_type": {
@@ -103,12 +103,28 @@
         "sponsor",
         "sponsor_url"
     ],
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "private": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "subnets"
+                ]
+            }
+        }
+    ],
     "dependentRequired": {
-        "private": [
-            "subnets"
+        "monopoly": [
+            "private"
         ]
     },
     "dependencies": {
-        "cloud_type": {"required": ["cloud_regions"]}
+        "cloud_type": {
+            "required": ["cloud_regions"]
+        }
     }
 }


### PR DESCRIPTION
- Wait for update the mirrors list before run ansible tests of the service
- Pass variable `source_path` to the backend environment
- Make pidfile when updating of the mirrors list is running and remove pidfile when it's ended
- Description of backend systemd service is fixed
- Version of JSON schema of a mirror config is increased
- Field `monopoly` is added to dataclass MirrorData
- DB migration for the new field is created
- It's removed duplicated modules: data_models.py & json_schemas.py
- Imports in a lot of modules are fixed
- The service returns only one private mirrors if it's
  suitable for client and the mirror is monopoly
- Some fixes in comments
- It's removed duplicated functions from mirrors_update.py
- Logging level of some messages from api.utils.py is reduced from exception to error
- It's fixed the issue with empty list AWS/Azure subnets
