### PR TITLE
Fix mirror check timer

### DIFF
--- a/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
+++ b/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
@@ -6,7 +6,7 @@ Requires=local_mirrors_list.service
 
 [Timer]
 OnStartupSec=1m
-OnUnitActiveSec=3600
+OnActiveSec=3600
 RandomizedDelaySec=300
 Persistent=true
 

--- a/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
+++ b/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
@@ -2,6 +2,7 @@
 Description={{ description }} Service
 Wants=network-online.target
 After=network.target network-online.target
+Requires=local_mirrors_list.service
 
 [Timer]
 OnStartupSec=1m

--- a/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
+++ b/ci/ansible/roles/deploy/templates/local_mirrors_list_timer.j2
@@ -2,7 +2,7 @@
 Description={{ description }} Service
 Wants=network-online.target
 After=network.target network-online.target
-Requires=local_mirrors_list.service
+Requires={{ mirrors_timer_name }}.service
 
 [Timer]
 OnStartupSec=1m


### PR DESCRIPTION
For some reason the timer to check/refresh mirrors broke.  The fix seems to be adding `Requires=` into the timer file.  We're quite sure this was working before just fine without it but something must've changed somewhere to now require it.