### PR TITLE
Add public FCIX mirror

### DIFF
--- a/mirrors.d/mirror.fcix.net.yml
+++ b/mirrors.d/mirror.fcix.net.yml
@@ -1,0 +1,16 @@
+---
+name: mirror.fcix.net
+address:
+  http: http://mirror.fcix.net/almalinux/
+update_frequency: 3h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: us
+  state_province: California
+  city: Fremont
+private: false
+monopoly: false
+...


### PR DESCRIPTION
We are setting up an update mirror service as part of the Fremont Cabal Internet Exchange. This is hosted on a Dell R520 inside the Hurricane Electric FMT2 datacenter with a 10G network connection.