### PR TITLE
Fixing FCIX country code to uppercase

### DIFF
--- a/mirrors.d/mirror.fcix.net.yml
+++ b/mirrors.d/mirror.fcix.net.yml
@@ -8,7 +8,7 @@ sponsor_url: https://fcix.net/
 email: mirror@fcix.net
 geolocation:
   continent: North America
-  country: us
+  country: US
   state_province: California
   city: Fremont
 private: false


### PR DESCRIPTION
Looking at the full list of mirrors in places like https://mirrors.almalinux.org/isos/x86_64/8.5.html it looks like the region is case sensitive, so since I entered it as `us` we were put in a region of our own, separate from `US` with everyone else.