### PR TITLE
New mirror in Greece

### DIFF
--- a/mirrors.d/ftp.cc.uoc.gr.yml
+++ b/mirrors.d/ftp.cc.uoc.gr.yml
@@ -1,0 +1,15 @@
+---
+name: ftp.cc.uoc.gr
+address:
+  http: http://ftp.cc.uoc.gr/mirrors/linux/almalinux/
+  https: https://ftp.cc.uoc.gr/mirrors/linux/almalinux/
+  ftp: ftp://ftp.cc.uoc.gr/mirrors/linux/almalinux/
+  rsync: rsync://ftp.cc.uoc.gr/almalinux/
+geolocation:
+  country: GR
+  state_province: Crete
+  city: Heraklion
+update_frequency: 4h
+sponsor: University of Crete - Department of Physics
+sponsor_url: https://www.physics.uoc.gr
+email: mirrors@cc.uoc.gr


### PR DESCRIPTION
Initial sync in progress.

Could be nice if repo.almalinux.org provided rsync access as well. Mirror site lists rsync://rsync.repo.almalinux.org/almalinux which is far/slow from EU