### PR TITLE
ALBS-213: Mirror service: provide URLs to older AlmaLinux versions

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -115,8 +115,10 @@ class RepoData:
 class MainConfig:
     allowed_outdate: str
     mirrors_dir: str
+    vault_mirror: str
     versions: list[str] = field(default_factory=list)
     duplicated_versions: list[str] = field(default_factory=list)
+    vault_versions: list[str] = field(default_factory=list)
     arches: list[str] = field(default_factory=list)
     required_protocols: list[str] = field(default_factory=list)
     repos: list[RepoData] = field(default_factory=list)

--- a/json_schemas/service_config.json
+++ b/json_schemas/service_config.json
@@ -18,6 +18,9 @@
                 "mirrors_table": {
                     "type": "string"
                 },
+                "vault_mirror": {
+                    "type": "string"
+                },
                 "versions": {
                     "type": "array",
                     "items": {
@@ -32,6 +35,19 @@
                     }
                 },
                 "duplicated_versions": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
+                    }
+                },
+                "vault_versions": {
                     "type": "array",
                     "items": {
                         "oneOf": [
@@ -72,6 +88,8 @@
                 "mirrors_dir",
                 "mirrors_table",
                 "repos",
+                "vault_mirror",
+                "vault_versions",
                 "versions"
             ],
             "title": "Welcome4"

--- a/utils.py
+++ b/utils.py
@@ -104,9 +104,13 @@ def process_main_config(
         return MainConfig(
             allowed_outdate=yaml_data['allowed_outdate'],
             mirrors_dir=yaml_data['mirrors_dir'],
+            vault_mirror=yaml_data.get('vault_mirror'),
             versions=[str(version) for version in yaml_data['versions']],
             duplicated_versions=[
                 str(version) for version in yaml_data['duplicated_versions']
+            ],
+            vault_versions=[
+                str(version) for version in yaml_data.get('vault_versions', [])
             ],
             arches=yaml_data['arches'],
             required_protocols=yaml_data['required_protocols'],


### PR DESCRIPTION
- It's update JSON schema of the service config and the config's data model
- The subject is implemented
- Copyright year is updated
