### PR TITLE
Add mirrors.kernel.org entries

### DIFF
--- a/mirrors.d/ap.edge.kernel.org.yml
+++ b/mirrors.d/ap.edge.kernel.org.yml
@@ -1,0 +1,12 @@
+---
+name: ap.edge.kernel.org
+address:
+  https: https://ap.edge.kernel.org/almalinux
+geolocation:
+  country: Japan
+  city: Tokyo
+update_frequency: 3h
+sponsor: Linux Kernel Archives
+sponsor_url: https://kernel.org
+email: ftpadmin@kernel.org
+...

--- a/mirrors.d/eu.edge.kernel.org.yml
+++ b/mirrors.d/eu.edge.kernel.org.yml
@@ -1,0 +1,12 @@
+---
+name: eu.edge.kernel.org
+address:
+  https: https://eu.edge.kernel.org/almalinux
+geolocation:
+  country: Netherlands
+  city: Amsterdam
+update_frequency: 3h
+sponsor: Linux Kernel Archives
+sponsor_url: https://kernel.org
+email: ftpadmin@kernel.org
+...

--- a/mirrors.d/mirrors.kernel.org.yml
+++ b/mirrors.d/mirrors.kernel.org.yml
@@ -1,0 +1,13 @@
+---
+name: mirrors.kernel.org
+address:
+  rsync: rsync://mirrors.kernel.org/almalinux
+geolocation:
+  country: US
+  state_province: California
+  city: San Jose
+update_frequency: 3h
+sponsor: Linux Kernel Archives
+sponsor_url: https://kernel.org
+email: ftpadmin@kernel.org
+...

--- a/mirrors.d/na.edge.kernel.org.yml
+++ b/mirrors.d/na.edge.kernel.org.yml
@@ -1,0 +1,13 @@
+---
+name: na.edge.kernel.org
+address:
+  https: https://na.edge.kernel.org/almalinux
+geolocation:
+  country: US
+  state_province: Texas
+  city: Dallas
+update_frequency: 3h
+sponsor: Linux Kernel Archives
+sponsor_url: https://kernel.org
+email: ftpadmin@kernel.org
+...


### PR DESCRIPTION
There are multiple nodes serving mirrors.kernel.org, with one of them
only serving rsync, and others only serving https. Normally, they are
accessed as mirrors.edge.kernel.org with geoDNS magic routing the
request to the nearest node, but it's possible to localize down to a
specific geographical area.

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>