### PR TITLE
ALBS-293: Mirror service: Add config option to set repo as available only on vault_mirror

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -108,6 +108,7 @@ class MirrorData:
 class RepoData:
     name: str
     path: str
+    vault: bool
     arches: list[str] = field(default_factory=list)
     versions: list[str] = field(default_factory=list)
 

--- a/json_schemas/service_config.json
+++ b/json_schemas/service_config.json
@@ -95,6 +95,9 @@
                 },
                 "versions": {
                     "$ref": "#/definitions/Versions"
+                },
+                "vault": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/utils.py
+++ b/utils.py
@@ -134,6 +134,7 @@ def process_main_config(
                         ],
                         attributes=[str(ver) for ver in yaml_data['versions']]
                     ),
+                    vault=repo.get('vault', False),
                 ) for repo in yaml_data['repos']
             ]
         ), None


### PR DESCRIPTION

- The JSON schema of the service config, loading the service config and the data model
  are changed according to implementation of the subject
- The separate function checks that a repo is vault or not