### PR TITLE
ALBS-293: Mirror service: Add config option to set repo as available only on vault_mirror

### DIFF
--- a/ci/ansible/roles/deploy/tasks/tests.yml
+++ b/ci/ansible/roles/deploy/tasks/tests.yml
@@ -14,10 +14,10 @@
     method: GET
     return_content: yes
   register: result
-  failed_when: " item.key not in result.content"
-  loop: "{{ azure_mirrors | dict2items }}"
+  failed_when: "item.key not in result.content"
+  loop: "{{ mirrors | dict2items }}"
   vars:
-    azure_mirrors:
+    mirrors:
       # Azure mirrors
       eastus.azure.repo.almalinux.org: "13.67.153.16"
       germanywestcentral.azure.repo.almalinux.org: "13.104.156.0"
@@ -26,4 +26,17 @@
       # CL private mirror
       centos.corp.cloudlinux.com: "77.79.198.14"
       # some public mirror
-      almalinux.ip-connect.vn.ua: "77.121.201.30"
+      almalinux.netforce.hosting: "77.121.201.30"
+
+- name: Check vault versions
+  uri:
+    url: "http://localhost/mirrorlist/{{ item }}/baseos"
+    method: GET
+    return_content: yes
+  register: result
+  failed_when: "result.content != 'http://repo.almalinux.org/vault/{{ item }}/BaseOS/$basearch/os/'"
+  with_items:
+    - "8.3"
+    - "8.4"
+    - "8.4-beta"
+    - "8.5-beta"

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -398,14 +398,14 @@ async def get_mirrors_list(
             repository,
             ', '.join(repos.keys()),
         )
-    if version not in versions:
+    if version not in versions + vault_versions:
         try:
             version = next(ver for ver in versions if version.startswith(ver))
         except StopIteration:
             raise UnknownRepositoryOrVersion(
                 'Unknown version "%s". Allowed list of versions "%s"',
                 version,
-                ', '.join(versions),
+                ', '.join(versions + vault_versions),
             )
     repo = repos[repository]
     repo_path = repo.path

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -368,9 +368,7 @@ def _is_vault_repo(
     :param repo: repo of requested a mirrors list
     """
 
-    if version in vault_versions:
-        return True
-    if repo.vault:
+    if version in vault_versions or repo.vault:
         return True
     return False
 

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -398,7 +398,7 @@ async def get_mirrors_list(
             repository,
             ', '.join(repos.keys()),
         )
-    if version not in versions + vault_versions:
+    if version not in versions and version not in vault_versions:
         try:
             version = next(ver for ver in versions if version.startswith(ver))
         except StopIteration:

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -370,9 +370,7 @@ def _is_vault_repo(
 
     if version in vault_versions:
         return True
-    if repo.vault and not repo.versions:
-        return True
-    if repo.vault and repo.versions and version in repo.versions:
+    if repo.vault:
         return True
     return False
 


### PR DESCRIPTION

- The JSON schema of the service config, loading the service config and the data model
  are changed according to implementation of the subject
- The separate function checks that a repo is vault or not