### PR TITLE
Adding back codingflyboy.mm.fcix.net after XSLT fix

### DIFF
--- a/mirrors.d/codingflyboy.mm.fcix.net.yml
+++ b/mirrors.d/codingflyboy.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: codingflyboy.mm.fcix.net
+address:
+  http: http://codingflyboy.mm.fcix.net/almalinux/
+  https: https://codingflyboy.mm.fcix.net/almalinux/
+  rsync: rsync://codingflyboy.mm.fcix.net/almalinux/
+update_frequency: 3h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: California
+  city: Fremont
+private: false
+monopoly: false
+...


### PR DESCRIPTION
The root cause for this mirror mangling the repomd.xml files was that
the xslt styling for directory indexes was being applied to "location /"
in Nginx, where the correct location to apply it was "location ~ /$" to
only apply the templating to paths ending in / such that there is no
way that actual assets could be modified.

Relevant commit in our playbook:
https://github.com/PhirePhly/micromirrors/commit/9057f49792ae3a648206910f320dbba7fc98bd35

I apologize for causing problems the first time. 