### PR TITLE
Assistance for development and local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 * Ansible version is 2.10 or newer
 * Ansible community.docker collection
     * Use command `ansible-galaxy collection install community.docker` for installing it
-* Ansible ssh-reconnect collection
-    * Use command `ansible-galaxy collection install udondan.ssh-reconnect` for installing it
+* Ansible ssh-reconnect role
+    * Use command `ansible-galaxy install udondan.ssh-reconnect` for installing it
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@
     7. Set value of option `test_ip_address` to test IP. This options is work only for non-production layout.
     8. Set value of option `gunicorn_port`. That is used for starting backend service.
 6. Go to project directory `ci/ansible`
-6. Run command `ansible-playbook -vv -i inventory/dev -u 
-   <username> --become main.yml`, there is `<username>` is name of a user from a remote server which has sudo rights
+6. Run command `ansible-playbook -vv -i inventory/vagrant -u vagrant --become main.yml`, `vagrant` with `-u` is name of a user from a remote server which has sudo rights
 
 ## How it works
 The service uses IP of a incoming request for detecting country and region. Therefore, a location can be different by expected if a server or you are using proxy, vpn, Cloudflare (or something like this).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "almalinux/8"
+  config.ssh.forward_agent = true
+  config.ssh.forward_x11 = true
+  config.vm.provider "libvirt" do |libvirt|
+    libvirt.cpus = 1
+    libvirt.memory = 2048
+    libvirt.random_hostname = true
+    libvirt.graphics_type = "spice"
+    libvirt.channel :type => 'spicevmc', :target_name => 'com.redhat.spice.0', :target_type => 'virtio'
+    libvirt.redirdev :type => "spicevmc"
+    libvirt.uri = 'qemu:///system'
+  end
+
+  config.vm.define "mirrors-service" do |i|
+    i.vm.hostname = "alma-8-mirrors-service"
+    i.vm.network "private_network", ip: "10.0.0.10"
+  end
+
+  config.vm.define "mirror1" do |i|
+    i.vm.hostname = "alma-8-mirror-1"
+    i.vm.network "private_network", ip: "10.0.0.11"
+  end
+
+end

--- a/ci/ansible/inventory/vagrant
+++ b/ci/ansible/inventory/vagrant
@@ -1,0 +1,15 @@
+[mirrors_service]
+10.0.0.10
+
+[all:vars]
+ansible_connection=ssh
+ansible_user=vagrant
+ansible_ssh_pass=vagrant
+container_env_prefix=prod
+deploy_environment=Production
+backend_workers=4
+auth_key=<your auth key for access to the endpoint of updating mirrors list>
+test_ip_address=<ip_address_of_request_for_debugging>
+gunicorn_port=<port of uwsgi service>
+license_key=<License key from MaxMind site>
+rsyslog_server=10.0.0.10

--- a/ci/ansible/inventory/vagrant
+++ b/ci/ansible/inventory/vagrant
@@ -6,6 +6,7 @@ ansible_connection=ssh
 ansible_user=vagrant
 ansible_ssh_pass=vagrant
 container_env_prefix=prod
+sentry_dsn=<place here a DSN key of your Sentry>
 deploy_environment=Production
 backend_workers=4
 auth_key=<your auth key for access to the endpoint of updating mirrors list>

--- a/ci/ansible/roles/deploy/defaults/main/packages.yml
+++ b/ci/ansible/roles/deploy/defaults/main/packages.yml
@@ -10,6 +10,7 @@ dnf_packages:
   - nginx
   - gcc
   # for testing purposes
+  - checkpolicy
   - sqlite
 python_packages:
   - aiodns==3.0.0


### PR DESCRIPTION
Several files have been added or updated to help us test and develop the environment locally with Vagrant and libvirt.

I added a basic setup so that you need to provide the missing information in `ci/ansible/inventory/vagrant` and you **should** be ready to spin a working machine with Vagrant and `ansible-playbook -vv -i inventory/vagrant -u vagrant --become main.yml`.