### PR TITLE
mirror-orange

### DIFF
--- a/add-mirror-orange
+++ b/add-mirror-orange
@@ -1,0 +1,15 @@
+---
+name: almalinux.mirrors.orange.ro
+address:
+  http: http://almalinux.mirrors.orange.ro
+  https: https://almalinux.mirrors.orange.ro
+  rsync: rsync://almalinux.mirrors.orange.ro
+geolocation:
+  country: RO
+  state_province: Bucharest
+  city: Bucharest
+update_frequency: 3h
+sponsor: Orange Romania Communications
+sponsor_url: https://orange.ro
+email: iulian.dragut@orange.com
+...


### PR DESCRIPTION
---
name: almalinux.mirrors.orange.ro
address:
  http: http://almalinux.mirrors.orange.ro
  https: https://almalinux.mirrors.orange.ro
  rsync: rsync://almalinux.mirrors.orange.ro
geolocation:
  country: RO
  state_province: Bucharest
  city: Bucharest
update_frequency: 3h
sponsor: Orange Romania Communications
sponsor_url: https://orange.ro
email: iulian.dragut@orange.com
...