### PR TITLE
Add mirror.accum.se

### DIFF
--- a/mirrors.d/mirror.accum.se.yml
+++ b/mirrors.d/mirror.accum.se.yml
@@ -1,0 +1,14 @@
+---
+name: mirror.accum.se
+address:
+  http: http://mirror.accum.se/mirror/almalinux.org/
+  https: https://mirror.accum.se/mirror/almalinux.org/
+  rsync: rsync://mirror.accum.se/mirror/almalinux.org/
+geolocation:
+  country: SE
+  state_province: Västerbotten
+  city: Umeå
+update_frequency: 3h
+sponsor: Academic Computer Club
+sponsor_url: https://www.accum.se
+email: ftp-adm@accum.se


### PR DESCRIPTION
This mirror has been syncing for a while now, it's time to promote it to a public mirror.

mirror.accum.se (perhaps more known under the old name ftp.acc.umu.se) enjoys 20 Gbps dedicated connectivity to SUNET, and excellent peering within Sweden and also the rest of Europe.
