### PR TITLE
ALBS-735: mirrors: return current minor version when client asks for major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
 
       - name: Check YAML configs
         run: |
-          mirror_regexp="mirrors.d/.*.yml"
+          mirror_regexp="mirrors.d/.*.(yml|yaml)$"
           if ! echo "${{ steps.files.outputs.all }}" | grep -E "${mirror_regexp}" &> /dev/null; then
             # we check only the main config if PR doesn't contain any mirror config
-            python3.9 gh_ci/config_checker.py -sc config.yml -ss gh_ci/yaml_snippets/json_schemas/service_config.json
+            python3.9 gh_ci/config_checker.py -sc config.yml
           else
             changed_files=""
             for changed_file in ${{ steps.files.outputs.all }}; do
@@ -50,5 +50,5 @@ jobs:
                 changed_files="${changed_file} ${changed_files}"
               fi
             done
-            python3.9 gh_ci/config_checker.py -sc config.yml -ss gh_ci/yaml_snippets/json_schemas/service_config.json -ms gh_ci/yaml_snippets/json_schemas/mirror_config.json -mc ${changed_files}
+            python3.9 gh_ci/config_checker.py -sc config.yml -mc ${changed_files}
           fi

--- a/config.yml
+++ b/config.yml
@@ -1,8 +1,6 @@
 ---
 allowed_outdate: 12h
-mirrorlist_dir: docs/.vuepress/public/mirrorlist
 mirrors_dir: mirrors.d
-mirrors_table: docs/internal/mirrors.md
 versions:
   - "8"
   - "8.6"

--- a/gh_ci/config_checker.py
+++ b/gh_ci/config_checker.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3.9
 import argparse
 import logging
+import os.path
 
 import yaml
-import json
 import requests
 
 from aiohttp import (
@@ -21,6 +21,7 @@ from yaml_snippets.utils import (
     process_main_config,
     process_mirror_config,
     mirror_available,
+    load_json_schema,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,19 +47,6 @@ class YamlFileType(argparse.FileType):
             )
 
 
-class JsonFileType(argparse.FileType):
-
-    def __call__(self, string):
-        file_stream = super(JsonFileType, self).__call__(string)
-        try:
-            return json.load(file_stream)
-        except json.JSONDecodeError as err:
-            raise argparse.ArgumentTypeError(
-                f'The JSON file by path "{file_stream.name}" '
-                f'is invalid because "{err}"'
-            )
-
-
 def create_parser():
     parser = argparse.ArgumentParser(
         description='The script checks validity of config (mirror or service) '
@@ -75,14 +63,6 @@ def create_parser():
         type=YamlFileType('r'),
     )
     parser.add_argument(
-        '-ss',
-        '--service-config-json-schema',
-        dest='service_config_json_schema',
-        help='Path to a JSON schema of service config.',
-        required=True,
-        type=JsonFileType('r'),
-    )
-    parser.add_argument(
         '-mc',
         '--mirror-configs',
         dest='mirror_configs',
@@ -90,13 +70,6 @@ def create_parser():
         default=[],
         nargs='+',
         type=YamlFileType('r'),
-    )
-    parser.add_argument(
-        '-ms',
-        '--mirror-config-json-schema',
-        dest='mirror_config_json_schema',
-        help='Path to a JSON schema of mirror config.',
-        type=JsonFileType('r'),
     )
     return parser
 
@@ -173,9 +146,16 @@ def do_mirrors_have_valid_geo_data(
 
 
 def main(args):
+    service_config_data = args.service_config['config_data']
+    service_config_version = service_config_data.get('config_version', 1)
+    json_schema_path = os.path.join(
+        'gh_ci/yaml_snippets/json_schemas/service_config',
+        f'v{service_config_version}.json',
+    )
+    json_schema = load_json_schema(path=json_schema_path)
     is_validity, err = config_validation(
-        yaml_data=args.service_config['config_data'],
-        json_schema=args.service_config_json_schema,
+        yaml_data=service_config_data,
+        json_schema=json_schema,
     )
     if is_validity:
         logger.info(
@@ -191,9 +171,16 @@ def main(args):
         exit(1)
     exit_code = 0
     for mirror_config in args.mirror_configs:
+        mirror_config_data = mirror_config['config_data']
+        mirror_config_version = mirror_config_data.get('config_version', 1)
+        json_schema_path = os.path.join(
+            'gh_ci/yaml_snippets/json_schemas/mirror_config',
+            f'v{mirror_config_version}.json',
+        )
+        json_schema = load_json_schema(path=json_schema_path)
         is_validity, err = config_validation(
-            yaml_data=args.service_config['config_data'],
-            json_schema=args.service_config_json_schema,
+            yaml_data=mirror_config_data,
+            json_schema=json_schema,
         )
         if is_validity:
             logger.info(


### PR DESCRIPTION
    - Versioning of service/mirror config and as a consequence we can use versioning for JSON schemas.
    - A mirror config with extension `*.yaml` also is valid now.
    - A few deprecated fields are removed from config.yml