### PR TITLE
Add mirrors.ft.uam.es

### DIFF
--- a/mirrors.d/mirrors.ft.uam.es.yml
+++ b/mirrors.d/mirrors.ft.uam.es.yml
@@ -1,0 +1,14 @@
+---
+name: mirrors.ft.uam.es
+address:
+  http: http://mirrors.ft.uam.es/almalinux/
+  https: https://mirrors.ft.uam.es/almalinux/
+geolocation:
+  country: ES
+  state_province: Comunidad de Madrid
+  city: Madrid
+update_frequency: 3h
+sponsor: Universidad Autónoma de Madrid
+sponsor_url: https://www.uam.es/uam/inicio
+email: pablo.collado@uam.es
+...


### PR DESCRIPTION
We have deployed an AlmaLinux mirror that's been syncing in a stable fashion for a couple of weeks now. We believe it's ready to be included in AlmaLinux's global mirror network.

Please do let us know if there's anything wrong or anything we might have missed.

Thanks for your time in advance!