### PR TITLE
Add mirror information for mirrors.dotsrc.org

### DIFF
--- a/mirrors.d/mirrors.dotsrc.org.yml
+++ b/mirrors.d/mirrors.dotsrc.org.yml
@@ -1,0 +1,16 @@
+---
+name: mirrors.dotsrc.org
+address:
+  http: http://mirrors.dotsrc.org/almalinux
+  https: https://mirrors.dotsrc.org/almalinux
+  rsync: rsync://mirrors.dotsrc.org/almalinux
+  ftp: ftp://mirrors.dotsrc.org/almalinux
+update_frequency: 2h
+sponsor: dotsrc
+sponsor_url: https://dotsrc.org/
+email: staff@dotsrc.org
+geolocation:
+  continent: Europe
+  country: DK
+  city: Aalborg
+...


### PR DESCRIPTION
This request adds our mirror at mirrors.dotsrc.org. I hope I filled out the json file correctly. I was a bit confused about the sponser information given that dotsrc has several [sponsers](https://dotsrc.org/sponsors/), but contact regarding the mirror should not go to them.
