### PR TITLE
- Fix the issue when a mirror's domain name can have more than one

### DIFF
--- a/src/backend/api/utils.py
+++ b/src/backend/api/utils.py
@@ -169,6 +169,11 @@ def get_geo_data_by_ip(
     continent = city.continent.name
     latitude = city.location.latitude
     longitude = city.location.longitude
+    if all(
+            name is None for name in
+            (continent, country, state, city_name, latitude, longitude)
+       ):
+        return None
 
     return continent, country, state, city_name, latitude, longitude
 

--- a/src/backend/common/sentry.py
+++ b/src/backend/common/sentry.py
@@ -40,6 +40,8 @@ def init_sentry_client(dsn: Optional[str] = None) -> None:
     :param dsn: project auth key
     """
     deploy_env_name = get_deploy_environment_name()
+    logging.basicConfig(level=logging.INFO)
+    logging.info('Current deploy environment "%s"', deploy_env_name)
     if dsn is None and os.getenv('SENTRY_DSN') is None:
         logging.warning('Sentry DSN is not defined')
     if dsn is None:


### PR DESCRIPTION
  DNS record of A type and some IPs from the records can have no geodata
- Log name of deploy environment when service of the backend is started