### PR TITLE
Add mirror.onlinehosting.com.tr

### DIFF
--- a/mirrors.d/mirror.onlinehosting.com.tr.yml
+++ b/mirrors.d/mirror.onlinehosting.com.tr.yml
@@ -1,0 +1,12 @@
+name: mirror.onlinehosting.com.tr
+address:
+  http: http://mirror.onlinehosting.com.tr/almalinux/
+  https: https://mirror.onlinehosting.com.tr/almalinux/
+geolocation:
+  country: TR
+  state_province: Ankara
+  city: Ankara
+update_frequency: 1h
+sponsor: Onlinehosting
+sponsor_url: https://www.onlinehosting.com.tr
+email: mirrors@onlinehosting.com.tr


### PR DESCRIPTION
```
name: mirror.onlinehosting.com.tr
address:
  http: http://mirror.onlinehosting.com.tr/almalinux/
  https: https://mirror.onlinehosting.com.tr/almalinux/
geolocation:
  country: TR
  state_province: Ankara
  city: Ankara
update_frequency: 1h
sponsor: Onlinehosting
sponsor_url: https://www.onlinehosting.com.tr
email: mirrors@onlinehosting.com.tr
```