### PR TITLE
ALBS-914: The mirrors service should process trailing slashes properly

### DIFF
--- a/ci/ansible/roles/deploy/tasks/redis_configuration.yml
+++ b/ci/ansible/roles/deploy/tasks/redis_configuration.yml
@@ -7,6 +7,20 @@
     state: present
     insertbefore: BOF
 
+- name: Disable RDB snapshots for Redis
+  lineinfile:
+    path: /etc/redis.conf
+    regexp: '^save .*'
+    state: absent
+    insertbefore: BOF
+
+- name: Disable RDB snapshots for Redis
+  lineinfile:
+    path: /etc/redis.conf
+    line: 'save ""'
+    state: present
+    insertbefore: BOF
+
 - name: Enable redis socket
   lineinfile:
     path: /etc/redis.conf

--- a/ci/ansible/roles/deploy/tasks/tests.yml
+++ b/ci/ansible/roles/deploy/tasks/tests.yml
@@ -56,9 +56,6 @@
   register: result
   failed_when: "'AlmaLinux ISOs links' not in result.content"
 
-
-
-
 - name: Check some mirrors in a request (ISOLJist)
   uri:
     url: "http://localhost/isolist/8/x86_64"

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -262,11 +262,11 @@ async def update_mirrors_handler() -> str:
                 arches=main_config.arches
             )
             subnets = await get_aws_subnets(
-                http_session=mirror_processor.client_session,
+                http_session=mirror_processor.client,
             )
             subnets.update(
                 await get_azure_subnets(
-                    http_session=mirror_processor.client_session,
+                    http_session=mirror_processor.client,
                 ),
             )
             for i in range(0, mirrors_len, step):

--- a/src/backend/api/utils.py
+++ b/src/backend/api/utils.py
@@ -18,6 +18,7 @@ from aiohttp import (
     ClientConnectorError,
 )
 import geopy
+from aiohttp_retry.types import ClientType
 from bs4 import BeautifulSoup
 from geoip2.errors import AddressNotFoundError
 from geopy.adapters import AioHTTPAdapter
@@ -243,7 +244,7 @@ async def get_aws_subnets_json(http_session: ClientSession) -> Optional[dict]:
     return response_json
 
 
-async def get_azure_subnets(http_session: ClientSession):
+async def get_azure_subnets(http_session: ClientType):
     subnets = await get_subnets_from_cache('azure_subnets')
     if subnets is not None:
         return subnets
@@ -261,7 +262,7 @@ async def get_azure_subnets(http_session: ClientSession):
     return subnets
 
 
-async def get_aws_subnets(http_session: ClientSession):
+async def get_aws_subnets(http_session: ClientType):
     subnets = await get_subnets_from_cache('aws_subnets')
     if subnets is not None:
         return subnets

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -41,6 +41,7 @@ from flask_bs4 import Bootstrap
 
 
 app = Flask('app')
+app.url_map.strict_slashes = False
 Bootstrap(app)
 logger = get_logger(__name__)
 init_sentry_client()


### PR DESCRIPTION
    - Disable RDB snapshots in Redis
    - Use RetryClient instead ClientSession
    - Set strict_slashes to False