### PR TITLE
Adding a link to become a sponsor.

### DIFF
--- a/src/backend/templates/mirrors.html
+++ b/src/backend/templates/mirrors.html
@@ -42,8 +42,12 @@
     If you want to set up a public mirror, please read
     <a href="https://wiki.almalinux.org/Mirrors.html"
        target="_blank"
-       class="link-success text-decoration-none">our mirror guidelines</a> {% include "snipets/link_icon.html" %}
-    <br>
+       class="link-success text-decoration-none">our mirror guidelines.</a> {% include "snipets/link_icon.html" %} 
+	Once you have set up a public mirror, we invite you to join the AlmaLinux OS Foundation as a Mirror Sponsor. Read more about how to apply and about all 
+    <a href="https://almalinux.org/members/"
+       target="_blank"
+       class="link-success text-decoration-none">membership opportunities here.</a> {% include "snipets/link_icon.html" %}
+    <br> 
     You can find the list of links to ISOs for all of mirrors by
     <a href="{{ url_for('.isos') }}"
        target="_self"


### PR DESCRIPTION
The membership committee has been getting feedback that folks didn't know you could become a sponsor through mirror hosting, and they specifically requested we add a link to the application to the mirrors page. I *think* I did this right, but feel free to edit if there's anything I missed!