### PR TITLE
Fix incorrect continent on mirror.yer.az

### DIFF
--- a/mirrors.d/mirror.yer.az.yml
+++ b/mirrors.d/mirror.yer.az.yml
@@ -4,7 +4,6 @@ address:
   http: http://mirror.yer.az/almalinux/
   https: https://mirror.yer.az/almalinux/
 geolocation:
-  continent: Europe
   country: AZ
   state_province: Baku
   city: Baku


### PR DESCRIPTION
Fix removing by continent key at all, Since the mirror service is able to find the correct continent