### PR TITLE
Added rsync to mirrors.sonic.net

### DIFF
--- a/mirrors.d/mirrors.sonic.net.yml
+++ b/mirrors.d/mirrors.sonic.net.yml
@@ -12,7 +12,6 @@ geolocation:
 asn:
    - 7065
    - 46375
-   - 
 update_frequency: 3h
 sponsor: Sonic.net, LLC
 sponsor_url: https://www.sonic.com/

--- a/mirrors.d/mirrors.sonic.net.yml
+++ b/mirrors.d/mirrors.sonic.net.yml
@@ -1,0 +1,20 @@
+---
+name: mirrors.sonic.net
+address:
+   https: https://mirrors.sonic.net/almalinux/
+   http: http://mirrors.sonic.net/almalinux/
+   ftp: ftp://mirrors.sonic.net/almalinux/
+geolocation:
+   continent: North America
+   country: US
+   state_province: California
+   city: Santa Rosa
+asn:
+   - 7065
+   - 46375
+   - 
+update_frequency: 3h
+sponsor: Sonic.net, LLC
+sponsor_url: https://www.sonic.com/
+email: hostmaster@sonic.net
+...

--- a/mirrors.d/mirrors.sonic.net.yml
+++ b/mirrors.d/mirrors.sonic.net.yml
@@ -16,5 +16,5 @@ asn:
 update_frequency: 3h
 sponsor: Sonic.net, LLC
 sponsor_url: https://www.sonic.com/
-email: hostmaster@sonic.net
+email: soc@sonic.net
 ...

--- a/mirrors.d/mirrors.sonic.net.yml
+++ b/mirrors.d/mirrors.sonic.net.yml
@@ -4,6 +4,7 @@ address:
    https: https://mirrors.sonic.net/almalinux/
    http: http://mirrors.sonic.net/almalinux/
    ftp: ftp://mirrors.sonic.net/almalinux/
+   rsync: rsync://mirrors.sonic.net/almalinux/
 geolocation:
    continent: North America
    country: US


### PR DESCRIPTION
We added almalinux to rsyncd, so adding rsync to the address list.