### PR TITLE
Set continent to OC

### DIFF
--- a/mirrors.d/mirror.aarnet.edu.au.yml
+++ b/mirrors.d/mirror.aarnet.edu.au.yml
@@ -10,7 +10,7 @@ sponsor: Australian Academic and Research Network
 sponsor_url: https://www.aarnet.edu.au
 email: mirror@aarnet.edu.au
 geolocation:
-  continent: Australia
+  continent: OC
   country: AU
   state_province: Victoria
   city: Melbourne


### PR DESCRIPTION
Correct mirror.aarnet.edu.au continent to OC. This also reflects the majority of the other Australian mirrors. 
