### PR TITLE
Temporarily set mirror as private

### DIFF
--- a/mirrors.d/mirrors.rda.run.yml
+++ b/mirrors.d/mirrors.rda.run.yml
@@ -11,4 +11,5 @@ update_frequency: 3h
 sponsor: Rodrigo de Avila
 sponsor_url: https://rda.run
 email: mirrors@rda.run
+private: true
 ...


### PR DESCRIPTION
I'm moving the server to another city. When the change is complete, I'll re-enable it.