### PR TITLE
Add OVHcloud mirror

### DIFF
--- a/mirrors.d/almalinux.mirrors.ovh.net
+++ b/mirrors.d/almalinux.mirrors.ovh.net
@@ -1,0 +1,12 @@
+---
+name: almalinux.mirrors.ovh.net
+address:
+  http: http://almalinux.mirrors.ovh.net/
+  https: https://almalinux.mirrors.ovh.net/
+geolocation:
+  country: FR
+update_frequency: 12h
+sponsor: OVHcloud
+sponsor_url: https://www.ovhcloud.com/
+email: mirror@ovh.net
+asn: 16276


### PR DESCRIPTION
Hi,
As discussed with @codyro and @jonathanspw, here is the pull request to add our mirror.

The IP address behind almalinux.mirrors.ovh.net uses anycast with locations in:
* Strasbourg (France)
* Roubaix (France)
* Gravelines (France)
* Beauharnois (Canada)

I set the country as "France" although it could be misleading but I don't have a good idea to make the mirror visible in Canada too. 