### PR TITLE
Rename OVHcloud mirror to use the proper extension

### DIFF
--- a/mirrors.d/almalinux.mirrors.ovh.net.yml
+++ b/mirrors.d/almalinux.mirrors.ovh.net.yml
@@ -4,9 +4,13 @@ address:
   http: http://almalinux.mirrors.ovh.net/
   https: https://almalinux.mirrors.ovh.net/
 geolocation:
+  continent: Europe
   country: FR
+  state_province: Hauts-de-France
+  city: Roubaix
 update_frequency: 12h
 sponsor: OVHcloud
 sponsor_url: https://www.ovhcloud.com/
 email: mirror@ovh.net
 asn: 16276
+...


### PR DESCRIPTION
Fixes 02c86298b14c6a.
Thanks to @jonathanspw for the heads-up!