### PR TITLE
Adding almalinux.linux.n0c.ca to the public mirror list

### DIFF
--- a/mirrors.d/almalinux.linux.n0c.ca.yml
+++ b/mirrors.d/almalinux.linux.n0c.ca.yml
@@ -1,0 +1,13 @@
+---
+name: almalinux.linux.n0c.ca
+address:
+  http: http://almalinux.linux.n0c.ca/almalinux/
+geolocation:
+  country: CA
+  state_province: QC
+  city: Montreal
+update_frequency: 3h
+sponsor: PlanetHoster
+sponsor_url: https://planethoster.com
+email: staff-infra@planethoster.info
+...


### PR DESCRIPTION
We have built this mirror to add to almalinux public mirrors. Only http is provided right now but more protocols can be offered if requested.