### PR TITLE
feat: add pkg.adfinis-on-exoscale.ch.yml

### DIFF
--- a/mirrors.d/pkg.adfinis-on-exoscale.ch.yml
+++ b/mirrors.d/pkg.adfinis-on-exoscale.ch.yml
@@ -1,0 +1,15 @@
+---
+name: pkg.adfinis-on-exoscale.ch
+address:
+  http: http://pkg.adfinis-on-exoscale.ch/almalinux/
+  https: https://pkg.adfinis-on-exoscale.ch/almalinux/
+geolocation:
+  country: CH
+  state_province: GE
+  city: Geneva
+update_frequency: 3h
+sponsor: Adfinis and Exoscale
+sponsor_url: https://www.adfinis.com
+sponsor_url: https://www.exoscale.com
+email: wolf@adfinis.com
+...


### PR DESCRIPTION
Hello

We at Adfinis have decided to host a AlmaLinux Mirror on our Mirror Server hosted by Exoscale.

Mirror:
- Owners: [Adfinis](https://adfinis.com) & [Exoscale](https://exoscale.com)
- http URL: [http://pkg.adfinis-on-exoscale.ch/almalinux/](http://pkg.adfinis-on-exoscale.ch/almalinux/)
- https URL: [https://pkg.adfinis-on-exoscale.ch/almalinux/](https://pkg.adfinis-on-exoscale.ch/almalinux/)
- rsync URL: currently not supported
- Location: Geneva, Switzerland
- Bandwidth: 10 Gbps
- Upstream: rsync://rsync.repo.almalinux.org/almalinux
- Sync frequency: every 3 hours
- Available storage: 50TB (Shared with other mirrors, currently 25TB
available)
- Admin email: wolf@adfinis.com

I am not sure how I should denote correctly that both Adfinis and Exoscale are hosting this server, could you give me some guidance.

Thank you very much.

