### PR TITLE
add mirror almalinux.mirror.rafal.ca

### DIFF
--- a/mirrors.d/almalinux.mirror.rafal.ca.yml
+++ b/mirrors.d/almalinux.mirror.rafal.ca.yml
@@ -1,0 +1,15 @@
+---
+name: almalinux.mirror.rafal.ca
+address:
+  http: http://almalinux.mirror.rafal.ca/
+  https: https://almalinux.mirror.rafal.ca/
+  rsync: rsync://almalinux.mirror.rafal.ca/almalinux
+geolocation:
+  country: CA
+  state_province: ON
+  city: Hamilton
+update_frequency: 3h
+sponsor: Rafał Rzeczkowski
+sponsor_url:
+email: mirror-almalinux@mail.rafal.ca
+...


### PR DESCRIPTION
I prepared a new public mirror for AlmaLinux.