### PR TITLE
Adding mirror.0x626b.com to alma mirrors list

### DIFF
--- a/mirrors.d/mirror.0x626b.com.yml
+++ b/mirrors.d/mirror.0x626b.com.yml
@@ -1,0 +1,18 @@
+---
+name: mirror.0x626b.com
+address:
+  http: http://mirror.0x626b.com/almalinux/
+  https: https://mirror.0x626b.com/almalinux/
+  rsync: rsync://mirror.0x626b.com/almalinux
+geolocation:
+  continent: North America
+  country: US
+  state_province: MO
+  city: Kansas City
+update_frequency: 3h
+sponsor: Brent Kolasinski
+sponsor_url: https://brentk.io
+email: mirroradmin@0x626b.com
+private: false
+monopoly: false
+...


### PR DESCRIPTION
New mirror for the Alma Linux project. This PR adds the mirror to the official list.