### PR TITLE
MicroMirrors with spare disk space from CentOS EOL

### DIFF
--- a/mirrors.d/abqix.mm.fcix.net.yml
+++ b/mirrors.d/abqix.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: abqix.mm.fcix.net
+address:
+  http: http://abqix.mm.fcix.net/almalinux/
+  https: https://abqix.mm.fcix.net/almalinux/
+  rsync: rsync://abqix.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: New Mexico
+  city: Albuquerque
+private: false
+monopoly: false
+...

--- a/mirrors.d/cofractal-ewr.mm.fcix.net.yml
+++ b/mirrors.d/cofractal-ewr.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: cofractal-ewr.mm.fcix.net
+address:
+  http: http://cofractal-ewr.mm.fcix.net/almalinux/
+  https: https://cofractal-ewr.mm.fcix.net/almalinux/
+  rsync: rsync://cofractal-ewr.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: New Jersey
+  city: Newark
+private: false
+monopoly: false
+...

--- a/mirrors.d/coresite.mm.fcix.net.yml
+++ b/mirrors.d/coresite.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: coresite.mm.fcix.net
+address:
+  http: http://coresite.mm.fcix.net/almalinux/
+  https: https://coresite.mm.fcix.net/almalinux/
+  rsync: rsync://coresite.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: Virginia
+  city: Sterling
+private: false
+monopoly: false
+...

--- a/mirrors.d/ix-denver.mm.fcix.net.yml
+++ b/mirrors.d/ix-denver.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: ix-denver.mm.fcix.net
+address:
+  http: http://ix-denver.mm.fcix.net/almalinux/
+  https: https://ix-denver.mm.fcix.net/almalinux/
+  rsync: rsync://ix-denver.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: Colorado
+  city: Castle Rock
+private: false
+monopoly: false
+...

--- a/mirrors.d/lesnet.mm.fcix.net.yml
+++ b/mirrors.d/lesnet.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: lesnet.mm.fcix.net
+address:
+  http: http://lesnet.mm.fcix.net/almalinux/
+  https: https://lesnet.mm.fcix.net/almalinux/
+  rsync: rsync://lesnet.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: CA
+  state_province: Manitoba
+  city: Winnipeg
+private: false
+monopoly: false
+...

--- a/mirrors.d/mnvoip.mm.fcix.net.yml
+++ b/mirrors.d/mnvoip.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: mnvoip.mm.fcix.net
+address:
+  http: http://mnvoip.mm.fcix.net/almalinux/
+  https: https://mnvoip.mm.fcix.net/almalinux/
+  rsync: rsync://mnvoip.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: Minnesota
+  city: Farmington
+private: false
+monopoly: false
+...

--- a/mirrors.d/paducahix.mm.fcix.net.yml
+++ b/mirrors.d/paducahix.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: paducahix.mm.fcix.net
+address:
+  http: http://paducahix.mm.fcix.net/almalinux/
+  https: https://paducahix.mm.fcix.net/almalinux/
+  rsync: rsync://paducahix.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: Kentucky
+  city: Paducah
+private: false
+monopoly: false
+...

--- a/mirrors.d/ridgewireless.mm.fcix.net.yml
+++ b/mirrors.d/ridgewireless.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: ridgewireless.mm.fcix.net
+address:
+  http: http://ridgewireless.mm.fcix.net/almalinux/
+  https: https://ridgewireless.mm.fcix.net/almalinux/
+  rsync: rsync://ridgewireless.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: California
+  city: Santa Clara
+private: false
+monopoly: false
+...

--- a/mirrors.d/veronanetworks.mm.fcix.net.yml
+++ b/mirrors.d/veronanetworks.mm.fcix.net.yml
@@ -1,0 +1,18 @@
+---
+name: veronanetworks.mm.fcix.net
+address:
+  http: http://veronanetworks.mm.fcix.net/almalinux/
+  https: https://veronanetworks.mm.fcix.net/almalinux/
+  rsync: rsync://veronanetworks.mm.fcix.net/almalinux/
+update_frequency: 2h
+sponsor: Fremont Cabal Internet Exchange
+sponsor_url: https://fcix.net/
+email: mirror@fcix.net
+geolocation:
+  continent: North America
+  country: US
+  state_province: Texas
+  city: Blue Ridge
+private: false
+monopoly: false
+...


### PR DESCRIPTION
Adding AlmaLinux to all the MicroMirrors which just got a bunch of spare disk space since CentOS is now end of life.

Note that the MicroMirrors are still syncing as of writing this, but they'll load up eventually and I just wanted to get this PR open before I closed my laptop for the day.