### PR TITLE
Create mirror.ox.ac.uk.yml

### DIFF
--- a/mirrors.d/mirror.ox.ac.uk.yml
+++ b/mirrors.d/mirror.ox.ac.uk.yml
@@ -9,7 +9,7 @@ geolocation:
   country: UK
   state_province: Oxfordshire
   city: Oxford
-update_frequency: 6h
+update_frequency: 3h
 sponsor: University of Oxford
 sponsor_url: https://www.ox.ac.uk
 email: unix-team-comms@it.ox.ac.uk

--- a/mirrors.d/mirror.ox.ac.uk.yml
+++ b/mirrors.d/mirror.ox.ac.uk.yml
@@ -1,0 +1,16 @@
+---
+name: mirror.ox.ac.uk
+address:
+  http: http://mirror.ox.ac.uk/sites/repo.almalinux.org/
+  https: https://mirror.ox.ac.uk/sites/repo.almalinux.org/
+  ftp: ftp://mirror.ox.ac.uk/sites/repo.almalinux.org/
+  rsync: rsync://mirror.ox.ac.uk/sites/repo.almalinux.org/
+geolocation:
+  country: UK
+  state_province: Oxfordshire
+  city: Oxford
+update_frequency: 6h
+sponsor: University of Oxford
+sponsor_url: https://www.ox.ac.uk
+email: unix-team-comms@it.ox.ac.uk
+private: true

--- a/mirrors.d/mirror.ox.ac.uk.yml
+++ b/mirrors.d/mirror.ox.ac.uk.yml
@@ -13,4 +13,4 @@ update_frequency: 6h
 sponsor: University of Oxford
 sponsor_url: https://www.ox.ac.uk
 email: unix-team-comms@it.ox.ac.uk
-private: true
+private: false


### PR DESCRIPTION
University of Oxford request to host its own mirror of AlmaLinux at mirror.ox.ac.uk