### PR TITLE
Add almalinux.linuxpatch.com mirror for UK

### DIFF
--- a/mirrors.d/almalinux.linuxpatch.com.yml
+++ b/mirrors.d/almalinux.linuxpatch.com.yml
@@ -1,0 +1,15 @@
+---
+name: almalinux.linuxpatch.com
+address:
+  http: http://almalinux.linuxpatch.com/
+  https: https://almalinux.linuxpatch.com/
+geolocation:
+  continent: Europe
+  country: UK
+  state_province: Greater London
+  city: London
+update_frequency: 12h
+sponsor: LinuxPatch.com
+sponsor_url: https://linuxpatch.com/
+email: support@linuxpatch.com
+...

--- a/mirrors.d/almalinux.linuxpatch.com.yml
+++ b/mirrors.d/almalinux.linuxpatch.com.yml
@@ -8,7 +8,7 @@ geolocation:
   country: UK
   state_province: Greater London
   city: London
-update_frequency: 12h
+update_frequency: 1h
 sponsor: LinuxPatch.com
 sponsor_url: https://linuxpatch.com/
 email: support@linuxpatch.com


### PR DESCRIPTION
# Pull Request: Add `almalinux.linuxpatch.com` as a Mirror for AlmaLinux

This pull request adds a new mirror, `almalinux.linuxpatch.com`, to the list of AlmaLinux mirrors. The mirror is hosted in London, UK, and is maintained by LinuxPatch.com. This addition enhances the distribution network within Europe, providing users in this region with improved access and download speeds for AlmaLinux resources.

## Changes Made

The following changes have been implemented to add the new mirror:

```yaml
---
name: almalinux.linuxpatch.com
address:
  http: http://almalinux.linuxpatch.com/
  https: https://almalinux.linuxpatch.com/
geolocation:
  continent: Europe
  country: UK
  state_province: Greater London
  city: London
update_frequency: 12h
sponsor: LinuxPatch.com
sponsor_url: https://linuxpatch.com/
email: support@linuxpatch.com
...