### PR TITLE
Preferring Funet ASN for nic.funet.fi

### DIFF
--- a/mirrors.d/nic.funet.fi.yml
+++ b/mirrors.d/nic.funet.fi.yml
@@ -13,4 +13,4 @@ update_frequency: 3h
 sponsor: CSC - IT Center for Science ltd / Finnish University and Research Network
 sponsor_url: https://www.csc.fi/en/home
 email: noc@funet.fi
-...
+asn: 1741


### PR DESCRIPTION
We'd prefer to have www.nic.funet.fi for the Funet ASN 1741 but still have others listed as alternative after it just in case. 
