### PR TITLE
Add Kitten to mirrors.ft.uam.es

### DIFF
--- a/mirrors.d/mirrors.ft.uam.es.yml
+++ b/mirrors.d/mirrors.ft.uam.es.yml
@@ -3,6 +3,10 @@ name: mirrors.ft.uam.es
 address:
   http: http://mirrors.ft.uam.es/almalinux/
   https: https://mirrors.ft.uam.es/almalinux/
+address_optional:
+  kitten:
+    http: http://mirrors.ft.uam.es/almalinux-kitten/
+    https: https://mirrors.ft.uam.es/almalinux-kitten/
 geolocation:
   country: ES
   state_province: Comunidad de Madrid


### PR DESCRIPTION
We just added the necessary configuration for our Kitten mirror as per [the documentation](https://wiki.almalinux.org/Mirrors.html).

If there's anything else that's needed please do let us know!

Thanks a ton for making AlmaLinux great :P