### PR TITLE
Solves AlmaLinux/mirrors#1143

### DIFF
--- a/ci/ansible/roles/deploy/tasks/backend_installation.yml
+++ b/ci/ansible/roles/deploy/tasks/backend_installation.yml
@@ -60,6 +60,7 @@
         - "{{ source_path }}/venv/bin/gunicorn"
       tags:
         - backend_selinux
+  when: ansible_facts.selinux.status == 'enabled'
 
 - name: Prepare started Py script
   template:

--- a/ci/ansible/roles/deploy/tasks/common_setup.yml
+++ b/ci/ansible/roles/deploy/tasks/common_setup.yml
@@ -18,6 +18,7 @@
     state: yes
     name: httpd_can_network_connect
     persistent: yes
+  when: ansible_facts.selinux.status == 'enabled'
 
 - name: Set config_root
   set_fact:

--- a/src/backend/api/mirror_processor.py
+++ b/src/backend/api/mirror_processor.py
@@ -98,7 +98,7 @@ class MirrorProcessor:
             },
         )
         self.client_session = ClientSession(
-            timeout=ClientTimeout(total=15,connect=10),
+            timeout=ClientTimeout(total=15, connect=10),
             connector=self.tcp_connector,
             headers=HEADERS,
             raise_for_status=True,
@@ -463,12 +463,18 @@ class MirrorProcessor:
     def get_mirror_iso_uris(
             self,
             versions: set[str],
-            arches: list,
+            arches: dict[str, list[str]],
             duplicated_versions
     ) -> list[str]:
         result = []
         for version in versions:
-            base_version = next((i for i in duplicated_versions if duplicated_versions[i] == version), version)
+            base_version = next(
+                (
+                    i for i in arches
+                    if version.startswith(i)
+                ),
+                version,
+            )
             for arch in arches[base_version]:
                 for iso_file_template in self.iso_files_templates:
                     iso_file = iso_file_template.format(

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -17,11 +17,12 @@ from api.handlers import (
     get_all_mirrors,
     get_isos_list_by_countries,
     get_main_isos_table,
-    get_allowed_arch,
     check_optional_version,
     get_optional_module_from_version,
     SERVICE_CONFIG_JSON_SCHEMA_DIR_PATH,
-    SERVICE_CONFIG_PATH, get_allowed_version, get_allowed_arch,
+    SERVICE_CONFIG_PATH,
+    get_allowed_version,
+    get_allowed_arch,
 )
 from werkzeug.exceptions import InternalServerError
 
@@ -57,6 +58,7 @@ if os.getenv('SENTRY_DSN'):
     init_sentry_client()
 cache = FlaskCacheEngine.get_instance(app)
 cache_ro = FlaskCacheEngineRo.get_instance(app)
+
 
 @app.context_processor
 def inject_now_date():
@@ -164,22 +166,38 @@ def get_mirror_list(
     
     # protocol get arg
     request_protocol = request.args.get('protocol')
-    if request_protocol and request_protocol not in ["http","https"]:
-        return "Invalid input for protocol, valid options: http, https"
+    if request_protocol and request_protocol not in ['http', 'https']:
+        return 'Invalid input for protocol, valid options: http, https'
     # country get arg
     request_country = request.args.get('country')
     if request_country and len(request_country) != 2:
-        return "Invalid input for country, valid options are 2 letter country codes"
+        return (
+            'Invalid input for country, '
+            'valid options are 2 letter country codes'
+        )
     # arch get arg
     request_arch = request.args.get('arch')
     if request_arch:
-        if not get_allowed_arch(arch=request_arch, version=version, arches=config.arches, duplicated_versions=config.duplicated_versions):
-            return f"Invalid arch/version combination requested, valid options are {config.arches}"
+        if not get_allowed_arch(
+            arch=request_arch,
+            version=version,
+            arches=config.arches,
+        ):
+            return (
+                'Invalid arch/version combination requested, '
+                f'valid options are {config.arches}'
+            )
     
     # check if optional module
     module = None
-    if version in check_optional_version(version=version, optional_module_versions=config.optional_module_versions):
-        module = get_optional_module_from_version(version=version, optional_module_versions=config.optional_module_versions)
+    if version in check_optional_version(
+        version=version,
+        optional_module_versions=config.optional_module_versions,
+    ):
+        module = get_optional_module_from_version(
+            version=version,
+            optional_module_versions=config.optional_module_versions,
+        )
     
     ip_address = _get_request_ip()
 
@@ -191,7 +209,12 @@ def get_mirror_list(
         request_protocol=request_protocol,
         request_country=request_country,
         debug_info=False,
-        redis_key=make_redis_key(ip=ip_address, protocol=request_protocol, country=request_country, module=module),
+        redis_key=make_redis_key(
+            ip=ip_address,
+            protocol=request_protocol,
+            country=request_country,
+            module=module,
+        ),
         module=module
     )
 
@@ -311,7 +334,6 @@ def isos(
             arch=arch,
             version=version,
             arches=config.arches,
-            duplicated_versions=config.duplicated_versions
         )
         data.update({
             'arch': arch,


### PR DESCRIPTION
- Check if SELinux is enabled during Ansible deploying
- PEP8 (long lines, indents, typing etc.)
- The unused import are removed, the rest imports are optimized
- Get right major version if a full version is not listed in duplicated versions (the main issue)
- Old field `versions_arches` is removed from the service config. Field `arches` provides the full compatibility with it