### PR TITLE
Solves AlmaLinux/mirrors#1143

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -94,7 +94,7 @@ class MirrorData:
     asn: list[str] = None
     monopoly: bool = False
     urls: dict[str, str] = field(default_factory=dict)
-    module_urls: dict[str, list] = field(default_factory=dict)
+    module_urls: dict[str, dict] = field(default_factory=dict)
     has_optional_modules: Optional[str] = None
     subnets: list[str] = field(default_factory=list)
     subnets_int: list[tuple] = field(default_factory=tuple)
@@ -152,12 +152,11 @@ class MainConfig:
     mirrors_dir: str
     vault_mirror: str
     versions: list[str] = field(default_factory=list)
-    optional_module_versions: dict[list] = field(default_factory=dict)
-    arches: list = field(default_factory=list)
+    optional_module_versions: dict[str, list[str]] = field(
+        default_factory=dict
+    )
+    arches: dict[str, list] = field(default_factory=dict)
     duplicated_versions: dict[str, str] = field(default_factory=dict)
     vault_versions: list[str] = field(default_factory=list)
-    versions_arches: dict[str, list[str]] = field(
-        default_factory=lambda: defaultdict(list)
-    )
     required_protocols: list[str] = field(default_factory=list)
     repos: list[RepoData] = field(default_factory=list)

--- a/json_schemas/service_config/v3.json
+++ b/json_schemas/service_config/v3.json
@@ -41,18 +41,6 @@
                     },
                     "additionalProperties": false
                 },
-                "versions_arches": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^.*$": {
-                            "$ref": "#/definitions/Arches"
-                        }
-                    },
-                    "propertyNames": {
-                        "$ref": "#/definitions/Version"
-                    },
-                    "additionalProperties": false
-                },
                 "vault_versions": {
                     "$ref": "#/definitions/Versions"
                 },

--- a/utils.py
+++ b/utils.py
@@ -527,10 +527,9 @@ def _is_permitted_arch_for_this_version_and_repo(
 ) -> bool:
     if version not in arches:
         return True
-    elif version in arches and arch in arches[version]:
+    elif arch in arches[version]:
         return True
-    else:
-        return False
+    return False
 
 
 def get_mirror_url(


### PR DESCRIPTION
- Check if SELinux is enabled during Ansible deploying
- PEP8 (long lines, indents, typing etc.)
- The unused import are removed, the rest imports are optimized
- Get right major version if a full version is not listed in duplicated versions (the main issue)
- Old field `versions_arches` is removed from the service config. Field `arches` provides the full compatibility with it