### PR TITLE
Update mirror.nodespace.com

### DIFF
--- a/mirrors.d/mirror.nodespace.com.yml
+++ b/mirrors.d/mirror.nodespace.com.yml
@@ -1,9 +1,9 @@
 ---
-name: mirror.nodespace.net
+name: mirror.nodespace.com
 address:
-  http: http://mirror.nodespace.net/almalinux/
-  https: https://mirror.nodespace.net/almalinux/
-  rsync: rsync://mirror.nodespace.net/almalinux/
+  http: http://mirror.nodespace.com/almalinux/
+  https: https://mirror.nodespace.com/almalinux/
+  rsync: rsync://mirror.nodespace.com/almalinux/
 geolocation:
   country: US
   state_province: North Carolina


### PR DESCRIPTION
The NodeSpace mirror is back online. Switching the domain from the legacy nodespace.net to current nodespace.com.