### PR TITLE
Create mirrors.hostiserver.com.yml

### DIFF
--- a/mirrors.d/mirrors.hostiserver.com.yml
+++ b/mirrors.d/mirrors.hostiserver.com.yml
@@ -1,0 +1,18 @@
+name: mirrors.hostiserver.com
+address:
+  http: http://mirrors.hostiserver.com/almalinux/
+  https: https://mirrors.hostiserver.com/almalinux/
+  rsync: rsync://mirrors.hostiserver.com/almalinux/
+  ftp: ftp://mirrors.hostiserver.com/almalinux/
+update_frequency: 3h
+sponsor: IT Services Company s.r.o.
+sponsor_url: https://www.hostiserver.com
+email: mirrors-admins@hostiserver.com
+geolocation:
+  continent: Europe
+  country: NL
+  state_province: Amsterdam
+  city: Amsterdam
+private: false
+monopoly: false
+...


### PR DESCRIPTION
a new mirror at https://mirrors.hostiserver.com/almalinux/
sponsored by IT Services Company s.r.o. (https://www.hostiserver.com)