### PR TITLE
Add nvidia repo to AlmaLinux 9.6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -168,6 +168,7 @@ repos:
     path: nvidia/$basearch/os/
     versions:
       - "10.0"
+      - "9.6"
     arches:
       - x86_64
       - aarch64


### PR DESCRIPTION
This PR adds nvidia repo to AlmaLinux 9.6 in addition to 10.0