### PR TITLE
URL change for mirrors.nic.cz

### DIFF
--- a/mirrors.d/almalinux.nic.cz.yml
+++ b/mirrors.d/almalinux.nic.cz.yml
@@ -1,9 +1,9 @@
 ---
-name: mirrors.nic.cz
+name: almalinux.nic.cz
 address:
-  http: http://mirrors.nic.cz/almalinux/
-  https: https://mirrors.nic.cz/almalinux/
-  rsync: rsync://mirrors.nic.cz/almalinux
+  http: http://almalinux.nic.cz/almalinux/
+  https: https://almalinux.nic.cz/almalinux/
+  rsync: rsync://almalinux.nic.cz/almalinux
 geolocation:
   country: CZ
   state_province: Prague


### PR DESCRIPTION
We are reworking our infrastructure behind mirrors.nic.cz, giving every project it's CNAME.