### PR TITLE
Add mirror.xcobean.co.ke (Nairobi, Kenya)

### DIFF
--- a/mirrors.d/mirror.xcobean.co.ke.yml
+++ b/mirrors.d/mirror.xcobean.co.ke.yml
@@ -1,0 +1,16 @@
+---
+name: mirror.xcobean.co.ke
+address:
+  http: https://mirror.xcobean.co.ke/almalinux/
+  https: https://mirror.xcobean.co.ke/almalinux/
+  rsync: rsync://mirror.xcobean.co.ke/almalinux/
+update_frequency: 6h
+sponsor: XcoBean Ltd
+sponsor_url: https://xcobean.co.ke
+email: admin@xcobean.co.ke
+geolocation:
+  country: KE
+  state_province: Nairobi
+  city: Nairobi
+private: false
+monopoly: false


### PR DESCRIPTION
## Summary
- Add XcoBean Ltd as an official AlmaLinux mirror located in Nairobi, Kenya
- Provides HTTP, HTTPS, and rsync access at `mirror.xcobean.co.ke/almalinux/`
- Sponsored by [XcoBean Ltd](https://xcobean.co.ke)

## Mirror details
| Field | Value |
|-------|-------|
| Name | mirror.xcobean.co.ke |
| HTTP | https://mirror.xcobean.co.ke/almalinux/ |
| RSYNC | rsync://mirror.xcobean.co.ke/almalinux/ |
| Location | Nairobi, Kenya |
| Sponsor | XcoBean Ltd |
| Contact | admin@xcobean.co.ke |
| IPv4 | Yes |
| IPv6 | Yes |
| Bandwidth | 1 Gbps |