### PR TITLE
Add Nhan Hoa mirror (Vietnam)

### DIFF
--- a/mirrors.d/mirrors.nhanhoa.com.yml
+++ b/mirrors.d/mirrors.nhanhoa.com.yml
@@ -1,0 +1,20 @@
+---
+name: mirrors.nhanhoa.com
+
+address:
+  http: http://mirrors.nhanhoa.com/almalinux
+  https: https://mirrors.nhanhoa.com/almalinux
+
+update_frequency: 2h
+
+sponsor: NhanHoa Company
+sponsor_url: https://nhanhoa.com
+email: dunght@nhanhoa.com.vn
+
+geolocation:
+  country: VN
+  state_province: Hanoi
+  city: Hanoi
+
+private: false
+monopoly: false


### PR DESCRIPTION
Hello AlmaLinux Team,

I'm from Nhan Hoa Software Company (Vietnam). 
We would like to add our mirror to the AlmaLinux mirror list. 
The configuration file for mirrors.nhanhoa.com has been added.

Please review and let us know if everything is correct.
Thank you!