### PR TITLE
Remove nvidia repository from configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -168,14 +168,6 @@ repos:
       - "8.10"
       - "9.7"
       - "10.1"
-  - name: nvidia
-    path: nvidia/$basearch/os/
-    versions:
-      - "10.1"
-      - "9.7"
-    arches:
-      - x86_64
-      - aarch64
 
   # sources repos
   - name: baseos-source


### PR DESCRIPTION
Removed nvidia repository configuration from config.yml.

The nvidia repo is no longer managed through the mirrorlist.  The previous nvidia repo will be available in vault.