### PR TITLE
Retire gh_ci/yaml_snippets submodule; sparse-fetch from mirrors_service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,20 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - name: Fetch yaml_snippets from mirrors_service branch
+        uses: actions/checkout@v4
+        with:
+          ref: mirrors_service
+          path: _mirrors_service
+          sparse-checkout: src/backend/yaml_snippets
+          sparse-checkout-cone-mode: false
+
+      - name: Stage yaml_snippets for config_checker
+        run: mv _mirrors_service/src/backend/yaml_snippets gh_ci/yaml_snippets
+
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "gh_ci/yaml_snippets"]
-	path = gh_ci/yaml_snippets
-	url = https://github.com/AlmaLinux/mirrors.git
-	branch = yaml_snippets


### PR DESCRIPTION
Drop the gh_ci/yaml_snippets submodule in favor of a second checkout step that sparse-fetches src/backend/yaml_snippets from the mirrors_service branch and moves it into gh_ci/yaml_snippets. Schema paths and imports in gh_ci/config_checker.py keep working unchanged.

Side benefits:
- master CI now validates mirror configs against the exact parser the service runs at runtime, so schema drift between branches is no longer possible.
- actions/checkout and actions/setup-python bumped from v2 (EOL) to v4 while the workflow was being edited.

Depends on the corresponding change on the mirrors_service branch which moves yaml_snippets from a submodule to regular files at the same path.