### PR TITLE
Show mirrorlist last-refresh time in page footer

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -74,10 +74,33 @@ def _get_bypass_cache() -> bool:
     )
 
 
+def _format_refresh_ago(seconds: float) -> str:
+    if seconds < 60:
+        return 'less than a minute ago'
+    minutes = int(seconds // 60)
+    if minutes < 60:
+        return f'{minutes} minute{"s" if minutes != 1 else ""} ago'
+    hours = minutes // 60
+    return f'{hours} hour{"s" if hours != 1 else ""} ago'
+
+
 @app.context_processor
 def inject_now_date():
+    now = datetime.now(timezone.utc)
+    last_refresh_ts = cache.get('mirrors_last_refresh')
+    if last_refresh_ts is not None:
+        last_refresh = datetime.fromtimestamp(last_refresh_ts, tz=timezone.utc)
+        last_refresh_utc = last_refresh.strftime('%Y-%m-%d %H:%M UTC')
+        last_refresh_ago = _format_refresh_ago(
+            (now - last_refresh).total_seconds(),
+        )
+    else:
+        last_refresh_utc = None
+        last_refresh_ago = None
     return {
-        'now': datetime.now(timezone.utc),
+        'now': now,
+        'last_refresh_utc': last_refresh_utc,
+        'last_refresh_ago': last_refresh_ago,
     }
 
 

--- a/src/backend/templates/main.html
+++ b/src/backend/templates/main.html
@@ -139,6 +139,11 @@
     <div class="container-fluid">
         <div class="row text-center">
             <div class="col-lg-12">© {{ now.year }} AlmaLinux OS Foundation</div>
+            {% if last_refresh_utc %}
+            <div class="col-lg-12 text-muted small">
+                Mirrorlist last refreshed {{ last_refresh_utc }} ({{ last_refresh_ago }})
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -3,6 +3,7 @@ import asyncio
 import itertools
 import os
 import time
+from datetime import datetime, timezone
 from inspect import signature
 from ipaddress import (
     ip_network,
@@ -203,6 +204,12 @@ async def update_mirrors_handler() -> str:
                 repeat=len(signature(get_all_mirrors_db).parameters)-1,
         ):
             get_all_mirrors_db(bypass_cache=True, *args)
+
+        cache.set(
+            'mirrors_last_refresh',
+            datetime.now(timezone.utc).timestamp(),
+            timeout=0,
+        )
     finally:
         logger.info(
             'Update of the mirrors list is finished at "%s"',


### PR DESCRIPTION
Record a UTC timestamp in Valkey when update_mirrors finishes, and render it in the footer as both an absolute UTC time and a relative "N minutes/hours ago" string.