### PR TITLE
update_mirrors: cut wall-clock and harden resource cleanup

### DIFF
--- a/ci/ansible/roles/deploy/templates/almalinux_mirror_list_update.service.j2
+++ b/ci/ansible/roles/deploy/templates/almalinux_mirror_list_update.service.j2
@@ -9,3 +9,4 @@ Group={{ service_user }}
 Type=oneshot
 ExecStart={{ scripts_path }}/{{ mirror_list_update }}.sh
 TimeoutStartSec=10min
+LimitNOFILE=65536

--- a/src/backend/api/handlers.py
+++ b/src/backend/api/handlers.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import itertools
 import os
 import random
 from collections import defaultdict
@@ -6,7 +7,7 @@ from dataclasses import asdict
 from typing import Optional, Union
 from urllib.parse import urljoin
 
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.expression import or_
 
 from api.exceptions import UnknownRepoAttribute
@@ -367,6 +368,65 @@ def get_all_mirrors_db(
 
     cache.set(cache_key, mirrors_list, 86400)
     return mirrors_list
+
+
+def _apply_mirror_filters(
+    mirrors: list[MirrorData],
+    get_working_mirrors: bool,
+    get_expired_mirrors: bool,
+    get_without_cloud_mirrors: bool,
+    get_without_private_mirrors: bool,
+    get_mirrors_with_full_set_of_isos: bool,
+) -> list[MirrorData]:
+    allowed_statuses = set()
+    if get_expired_mirrors:
+        allowed_statuses.add('expired')
+    if get_working_mirrors:
+        allowed_statuses.add('ok')
+    result = []
+    for m in mirrors:
+        if get_without_private_mirrors and m.private:
+            continue
+        if get_mirrors_with_full_set_of_isos and not m.has_full_iso_set:
+            continue
+        if allowed_statuses and m.status not in allowed_statuses:
+            continue
+        if get_without_cloud_mirrors and m.cloud_type != '':
+            continue
+        result.append(m)
+    return result
+
+
+def warm_all_mirrors_cache() -> None:
+    # Pull every mirror once with relationships eager-loaded, convert to
+    # MirrorData, then filter in Python for each flag combination and MSET
+    # the whole batch. Replaces 32 sequential DB queries + 32 Redis round-trips.
+    with session_scope() as session:
+        all_orm = session.query(Mirror).options(
+            selectinload(Mirror.urls),
+            selectinload(Mirror.module_urls),
+            selectinload(Mirror.subnets),
+            selectinload(Mirror.subnets_int),
+        ).order_by(
+            Mirror.continent,
+            Mirror.country,
+        ).all()
+        all_mirrors = [m.to_dataclass() for m in all_orm]
+
+    flag_names = (
+        'get_working_mirrors',
+        'get_expired_mirrors',
+        'get_without_cloud_mirrors',
+        'get_without_private_mirrors',
+        'get_mirrors_with_full_set_of_isos',
+    )
+    batch = {}
+    for values in itertools.product((True, False), repeat=len(flag_names)):
+        flags = dict(zip(flag_names, values))
+        cache_key = _generate_redis_key_for_the_mirrors_list(**flags)
+        batch[cache_key] = _apply_mirror_filters(all_mirrors, **flags)
+
+    cache.set_many(batch, timeout=86400)
 
 
 def _is_vault_repo(

--- a/src/backend/api/mirror_processor.py
+++ b/src/backend/api/mirror_processor.py
@@ -309,8 +309,11 @@ class MirrorProcessor:
                 longitude=cached_longitude,
             )
             return
+        locationiq_key = os.getenv('LOCATIONIQ_KEY')
+        if not locationiq_key:
+            return
         params = {
-            'key': os.getenv('LOCATIONIQ_KEY'),
+            'key': locationiq_key,
             'city': mirror_info.geolocation.city,
             'state': mirror_info.geolocation.state_province,
             'country': mirror_info.geolocation.country,

--- a/src/backend/api/mirror_processor.py
+++ b/src/backend/api/mirror_processor.py
@@ -299,10 +299,6 @@ class MirrorProcessor:
                 mirror_info.geolocation.state_province,
             )
             return
-        self.logger.info(
-            'Set geodata for mirror "%s" from online DB',
-            mirror_info.name,
-        )
         redis_key = (
             f'nominatim_{mirror_info.geolocation.country}_'
             f'{mirror_info.geolocation.state_province}_'
@@ -321,6 +317,10 @@ class MirrorProcessor:
         locationiq_key = os.getenv('LOCATIONIQ_KEY')
         if not locationiq_key:
             return
+        self.logger.info(
+            'Set geodata for mirror "%s" from online DB',
+            mirror_info.name,
+        )
         params = {
             'key': locationiq_key,
             'city': mirror_info.geolocation.city,

--- a/src/backend/api/mirror_processor.py
+++ b/src/backend/api/mirror_processor.py
@@ -2,6 +2,8 @@ import os
 import asyncio
 from asyncio import CancelledError
 from asyncio.exceptions import TimeoutError
+from datetime import datetime, timezone
+from functools import lru_cache
 from logging import Logger
 from typing import Optional, Union
 from urllib.parse import urljoin
@@ -47,6 +49,13 @@ from yaml_snippets.utils import (
     check_tasks,
     get_mirror_url,
 )
+
+
+@lru_cache(maxsize=8)
+def _allowed_outdate_seconds(outdate: str) -> float:
+    # dateparser is too slow to call per-mirror; cache the interval in seconds.
+    now = datetime.now(timezone.utc).timestamp()
+    return now - dateparser.parse(f'now-{outdate} UTC').timestamp()
 
 
 class MirrorProcessor:
@@ -484,9 +493,10 @@ class MirrorProcessor:
         main_config: MainConfig,
         module: Optional[str] = None
     ):
-        mirror_should_updated_at = dateparser.parse(
-            f'now-{main_config.allowed_outdate} UTC'
-        ).timestamp()
+        mirror_should_updated_at = (
+            datetime.now(timezone.utc).timestamp()
+            - _allowed_outdate_seconds(main_config.allowed_outdate)
+        )
         timestamp_url = urljoin(
             get_mirror_url(
                 main_config=main_config,

--- a/src/backend/api/mirror_processor.py
+++ b/src/backend/api/mirror_processor.py
@@ -130,6 +130,7 @@ class MirrorProcessor:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.client.close()
+        self.dns_resolver.cancel()
 
     async def request(
         self,

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -78,7 +78,7 @@ async def update_mirrors_handler() -> str:
     message = 'Update of the mirrors list is finished at "%s"'
     try:
         logger.info('Update of the mirrors list is started')
-        mirror_check_sem = asyncio.Semaphore(200)
+        mirror_check_sem = asyncio.Semaphore(100)
         async with mirror_check_sem, MirrorProcessor(
                 logger=logger,
         ) as mirror_processor:  # type: MirrorProcessor

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -2,6 +2,7 @@
 import asyncio
 import itertools
 import os
+import resource
 import time
 from datetime import datetime, timezone
 from inspect import signature
@@ -45,6 +46,11 @@ from db.utils import session_scope
 from yaml_snippets.utils import (
     get_mirrors_info,
 )
+
+# Raise the soft FD limit to the hard ceiling so high-concurrency mirror
+# checks don't hit the default per-process 1024 cap when run outside systemd.
+_, _fd_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+resource.setrlimit(resource.RLIMIT_NOFILE, (_fd_hard, _fd_hard))
 
 app = Flask('app')
 app.url_map.strict_slashes = False

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -1,11 +1,9 @@
 # coding=utf-8
 import asyncio
-import itertools
 import os
 import resource
 import time
 from datetime import datetime, timezone
-from inspect import signature
 from ipaddress import (
     ip_network,
     IPv4Network,
@@ -20,7 +18,7 @@ from flask_bs4 import Bootstrap
 from sqlalchemy import insert
 
 from api.handlers import (
-    get_all_mirrors_db,
+    warm_all_mirrors_cache,
 )
 from api.mirror_processor import MirrorProcessor
 from api.utils import (
@@ -204,12 +202,7 @@ async def update_mirrors_handler() -> str:
 
         db_session.commit()
 
-        # update all mirrors lists in the Redis cache
-        for args in itertools.product(
-                (True, False),
-                repeat=len(signature(get_all_mirrors_db).parameters)-1,
-        ):
-            get_all_mirrors_db(bypass_cache=True, *args)
+        warm_all_mirrors_cache()
 
         cache.set(
             'mirrors_last_refresh',

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -74,7 +74,7 @@ async def update_mirrors_handler() -> str:
     message = 'Update of the mirrors list is finished at "%s"'
     try:
         logger.info('Update of the mirrors list is started')
-        mirror_check_sem = asyncio.Semaphore(100)
+        mirror_check_sem = asyncio.Semaphore(200)
         async with mirror_check_sem, MirrorProcessor(
                 logger=logger,
         ) as mirror_processor:  # type: MirrorProcessor

--- a/src/backend/update_mirrors.py
+++ b/src/backend/update_mirrors.py
@@ -225,10 +225,10 @@ async def update_mirrors_handler() -> str:
 
 
 async def check_mirror(mirror_check_sem, mirror_info, main_config, mirror_iso_uris, subnets):
-    async with mirror_check_sem:
-        async with MirrorProcessor(
-                logger=logger,
-        ) as mirror_processor:
+    async with MirrorProcessor(
+            logger=logger,
+    ) as mirror_processor:
+        async with mirror_check_sem:
             await mirror_processor.set_ip_for_mirror(
                 mirror_info=mirror_info
             )
@@ -260,9 +260,12 @@ async def check_mirror(mirror_check_sem, mirror_info, main_config, mirror_iso_ur
                         mirror_info=mirror_info,
                         mirror_iso_uris=mirror_iso_uris
                     )
-                await mirror_processor.set_location_data_from_online_service(
-                    mirror_info=mirror_info
-                )
+        # Online geocoding runs outside the check semaphore: holding a slot while
+        # waiting on the class-level 1 req/s LocationIQ lock starves newcomers.
+        if mirror_info.status in ('ok', 'expired') and mirror_info.ip not in ('Unknown', None):
+            await mirror_processor.set_location_data_from_online_service(
+                mirror_info=mirror_info
+            )
 
 
 async def update_mirrors():

--- a/src/backend/yaml_snippets/utils.py
+++ b/src/backend/yaml_snippets/utils.py
@@ -591,6 +591,7 @@ async def mirror_available(
         )
         return True, None
     urls_for_checking = {}
+    mirror_base = mirror_info.mirror_url.rstrip('/')
     for version in main_config.versions:
         # cloud mirrors (Azure/AWS) don't store beta versions
         if mirror_info.cloud_type and 'beta' in version:
@@ -633,15 +634,9 @@ async def mirror_available(
                 ):
                     continue
                 repo_path = repo_data.path.replace('$basearch', arch)
-                url_for_check = urljoin(
-                    urljoin(
-                        urljoin(
-                            mirror_info.mirror_url + '/',
-                            str(version),
-                        ) + '/',
-                        repo_path,
-                    ) + '/',
-                    'repodata/repomd.xml',
+                url_for_check = (
+                    f"{mirror_base}/{version}/"
+                    f"{repo_path.strip('/')}/repodata/repomd.xml"
                 )
                 urls_for_checking[url_for_check] = {
                     'version': version,

--- a/src/backend/yaml_snippets/utils.py
+++ b/src/backend/yaml_snippets/utils.py
@@ -131,6 +131,10 @@ async def check_tasks(
         if not result:
             for pending_task in pending_tasks:
                 pending_task.cancel()
+            # Wait for cancellations to land so callers (e.g. MirrorProcessor.__aexit__)
+            # don't close the ClientSession out from under a still-live task.
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
             return False, reason
     if not pending_tasks:
         return True, None


### PR DESCRIPTION
## Summary
- Cut update_mirrors wall-clock: cache dateparser intervals, flatten repodata URL construction, skip LocationIQ entirely when `LOCATIONIQ_KEY` is unset, and batch the post-insert cache warmup into one eager-loaded query + one Redis MSET (was 32 queries with N+1 tails and 32 sequential SETs).
- Stop the ~1/s tail trickle by moving LocationIQ geocoding out of the per-mirror check semaphore — slots no longer block on the global 1 req/s rate lock.
- Harden resource cleanup: raise `RLIMIT_NOFILE` at startup (+ `LimitNOFILE=65536` on the systemd unit), close each `MirrorProcessor`'s aiodns `DNSResolver` explicitly so cleanup doesn't fan out into ~200 pycares shutdown threads, and await cancelled tasks on the `check_tasks` fail-fast path so they can't hit `ClientSession` after it closes.
- Fix a misleading "from online DB" log line that fired before the Redis cache / key-missing short-circuits.