### PR TITLE
Set system timezone to UTC via ansible

### DIFF
--- a/ci/ansible/roles/deploy/defaults/main/packages.yml
+++ b/ci/ansible/roles/deploy/defaults/main/packages.yml
@@ -10,6 +10,7 @@ dnf_packages:
   - gcc
   - epel-release
   - nfs-utils
+  - tzdata
   # for testing purposes
   - checkpolicy
   - sqlite

--- a/ci/ansible/roles/deploy/tasks/common_setup.yml
+++ b/ci/ansible/roles/deploy/tasks/common_setup.yml
@@ -13,6 +13,10 @@
   tags:
     - update_packages
 
+- name: Set system timezone to UTC
+  community.general.timezone:
+    name: Etc/UTC
+
 - name: Set SELinux option for right working of nginx + Gunicorn
   seboolean:
     state: yes


### PR DESCRIPTION
Avoids tzlocal's "Can not find any timezone configuration" warning on minimal hosts that ship without /etc/localtime or /etc/timezone.