### PR TITLE
Add mirror.plusline.net

### DIFF
--- a/mirrors.d/mirror.plusline.net.yaml
+++ b/mirrors.d/mirror.plusline.net.yaml
@@ -1,0 +1,15 @@
+---
+name: mirror.plusline.net
+address:
+  http: http://mirror.plusline.net/almalinux/
+  https: https://mirror.plusline.net/almalinux/
+  rsync: rsync://mirror.plusline.net/almalinux
+geolocation:
+  country: DE
+  state_province: Hesse
+  city: Frankfurt am Main
+update_frequency: 4h
+sponsor: Plus.line AG
+sponsor_url: https://www.plusline.net
+email: ftp@plusline.net
+...


### PR DESCRIPTION
This pull request adds the mirror server “mirror.plusline.net”, which is based in Frankfurt am Main, Germany.