### PR TITLE
Add Blowfish Technology AlmaLinux mirror

### DIFF
--- a/mirrors.d/almalinux.mirror.blowfish.network.yml
+++ b/mirrors.d/almalinux.mirror.blowfish.network.yml
@@ -1,0 +1,17 @@
+---
+name: almalinux.mirror.blowfish.network
+address:
+  https: https://almalinux.mirror.blowfish.network
+  rsync: rsync://almalinux.mirror.blowfish.network/almalinux
+update_frequency: 6h
+sponsor: Blowfish Technology
+sponsor_url: https://blowfishtechnology.com
+email: graham.p@blowfish.network
+geolocation:
+  country: GB
+  state_province:  Greater Manchester
+  city: Manchester
+private: false
+monopoly: false
+asn: 61323
+...


### PR DESCRIPTION
Adds a new public AlmaLinux mirror hosted in the United Kingdom.

Hostname:

almalinux.mirror.blowfish.network

Protocols:

- HTTPS

- rsync

Network:

AS61323

Location:

Manchester, Greater Manchester, GB