### PR TITLE
Change allowed_outdate from 12h to 1h

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 ---
 config_version: 3
-allowed_outdate: 12h
+allowed_outdate: 1h
 mirrors_dir: mirrors.d
 versions:
   - "8"


### PR DESCRIPTION
This is to facilitate a smoother rollout of copy fail (CVE-2026-31431) patches