### PR TITLE
Fix missing trailing slashes in mirror.tzulo.com URLs

### DIFF
--- a/mirrors.d/mirror.tzulo.com.yml
+++ b/mirrors.d/mirror.tzulo.com.yml
@@ -2,8 +2,8 @@
 name: mirror.tzulo.com  
 address:
   http: http://mirror.tzulo.com/almalinux/
-  https: https://mirror.tzulo.com/almalinux
-  rsync: rsync://mirror.tzulo.com/almalinux
+  https: https://mirror.tzulo.com/almalinux/
+  rsync: rsync://mirror.tzulo.com/almalinux/
 geolocation:
   country: US
   state_province: IL


### PR DESCRIPTION
Add trailing slashes to https and rsync addresses.