### PR TITLE
Add mirror.hostarts.dz (Algiers, Algeria)

### DIFF
--- a/mirrors.d/mirror.hostarts.dz.yml
+++ b/mirrors.d/mirror.hostarts.dz.yml
@@ -1,0 +1,14 @@
+name: mirror.hostarts.dz
+address:
+  http: http://mirror.hostarts.dz/almalinux/
+  https: https://mirror.hostarts.dz/almalinux/
+  rsync: rsync://mirror.hostarts.dz/almalinux
+update_frequency: 3h
+sponsor: HOSTARTS
+sponsor_url: https://hostarts.dz
+email: h.chergui@hostarts.com
+geolocation:
+  country: DZ
+  state_province: DZ-16
+  city: Algiers
+...


### PR DESCRIPTION
Adding a new public mirror in Algiers, Algeria — to our knowledge the first AlmaLinux mirror in the country.

- **HTTP:** http://mirror.hostarts.dz/almalinux/
- **HTTPS:** https://mirror.hostarts.dz/almalinux/
- **rsync:** rsync://mirror.hostarts.dz/almalinux
- **Sponsor:** HOSTARTS (https://hostarts.dz), AS329667
- **Sync:** every 3 hours from rsync.repo.almalinux.org
- **Connection:** 1 Gbps

Note: we recently converted from a partial to a full mirror; the full-tree fill from the official rsync source is completing within the next ~24h, so early validation probes may briefly see missing paths. Happy to re-trigger checks once it settles.

Contact: h.chergui@hostarts.com