### PR TITLE
Update mirror: repo.mirror.famaserver.com → mirror.famaserver.comFamaserver patch 1

### DIFF
--- a/mirrors.d/repo.mirror.famaserver.com.yml
+++ b/mirrors.d/repo.mirror.famaserver.com.yml
@@ -1,0 +1,15 @@
+---
+name: repo.mirror.famaserver.com
+address:
+  https: https://repo.mirror.famaserver.com/almalinux/
+update_frequency: 3h
+sponsor: FamaServer
+sponsor_url: https://famaserver.com
+email: info@famaserver.com
+geolocation:
+  continent: Asia
+  country: IR
+  state_province: Tehran
+  city: Tehran
+private: false
+monopoly: false


### PR DESCRIPTION
Our mirror moved to a new host and hostname.

- Old: repo.mirror.famaserver.com (server decommissioned)
- New: mirror.famaserver.com — Tehran, Iran, 1 Gbps

Fully synced: AlmaLinux 8, 9 and 10, all architectures, ISOs included
(~1.4 TB), updated every 3 hours from rsync.repo.almalinux.org.

Plain HTTP and rsync are now available too, so both were added alongside
the existing HTTPS entry.

Verify:
  https://mirror.famaserver.com/almalinux/9/BaseOS/x86_64/os/repodata/repomd.xml

Sponsored by FamaServer — https://famaserver.com